### PR TITLE
Rework player API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 💥 Renamed `PlayerState` to `Player`.
+* 🚀 Added overloads to `DefaultUI` and `UIController` that accept a `Player`.
+  This allows constructing a player instance in advance, and even moving it between custom UIs when recomposing.
+* 🚀 Added `UIControllerScope.player` as an non-null alternative to `Player.current`. 
+
 ## v1.1.0 (2023-06-27)
 
 * 💥 Update to THEOplayer Android SDK 5.

--- a/app/src/main/java/com/theoplayer/android/ui/demo/MainActivity.kt
+++ b/app/src/main/java/com/theoplayer/android/ui/demo/MainActivity.kt
@@ -18,7 +18,7 @@ import com.theoplayer.android.api.source.TypedSource
 import com.theoplayer.android.ui.DefaultUI
 import com.theoplayer.android.ui.demo.nitflex.NitflexUI
 import com.theoplayer.android.ui.demo.nitflex.theme.NitflexTheme
-import com.theoplayer.android.ui.rememberTHEOplayer
+import com.theoplayer.android.ui.rememberPlayer
 import com.theoplayer.android.ui.theme.THEOplayerTheme
 
 class MainActivity : ComponentActivity() {
@@ -41,7 +41,7 @@ fun MainContent() {
             .build()
     ).build()
 
-    val player = rememberTHEOplayer()
+    val player = rememberPlayer()
     LaunchedEffect(key1 = player, key2 = source) {
         player.player?.source = source
     }

--- a/app/src/main/java/com/theoplayer/android/ui/demo/MainActivity.kt
+++ b/app/src/main/java/com/theoplayer/android/ui/demo/MainActivity.kt
@@ -13,13 +13,12 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.theoplayer.android.api.THEOplayerConfig
-import com.theoplayer.android.api.player.track.texttrack.TextTrackKind
 import com.theoplayer.android.api.source.SourceDescription
-import com.theoplayer.android.api.source.TextTrackDescription
 import com.theoplayer.android.api.source.TypedSource
 import com.theoplayer.android.ui.DefaultUI
 import com.theoplayer.android.ui.demo.nitflex.NitflexUI
 import com.theoplayer.android.ui.demo.nitflex.theme.NitflexTheme
+import com.theoplayer.android.ui.rememberTHEOplayer
 import com.theoplayer.android.ui.theme.THEOplayerTheme
 
 class MainActivity : ComponentActivity() {
@@ -41,6 +40,11 @@ fun MainContent() {
         TypedSource.Builder("https://amssamples.streaming.mediaservices.windows.net/7ceb010f-d9a3-467a-915e-5728acced7e3/ElephantsDreamMultiAudio.ism/manifest(format=mpd-time-csf)")
             .build()
     ).build()
+
+    val player = rememberTHEOplayer()
+    LaunchedEffect(key1 = player, key2 = source) {
+        player.player?.source = source
+    }
 
     var themeMenuOpen by remember { mutableStateOf(false) }
     var theme by rememberSaveable { mutableStateOf(PlayerTheme.Default) }
@@ -75,17 +79,16 @@ fun MainContent() {
                 PlayerTheme.Default -> {
                     DefaultUI(
                         modifier = Modifier.padding(padding),
-                        config = THEOplayerConfig.Builder().build(),
-                        source = source,
+                        player = player,
                         title = "Elephant's Dream"
                     )
                 }
+
                 PlayerTheme.Nitflex -> {
                     NitflexTheme(useDarkTheme = true) {
                         NitflexUI(
                             modifier = Modifier.padding(padding),
-                            config = THEOplayerConfig.Builder().build(),
-                            source = source,
+                            player = player,
                             title = "Elephant's Dream"
                         )
                     }

--- a/app/src/main/java/com/theoplayer/android/ui/demo/nitflex/NitflexUI.kt
+++ b/app/src/main/java/com/theoplayer/android/ui/demo/nitflex/NitflexUI.kt
@@ -1,11 +1,23 @@
 package com.theoplayer.android.ui.demo.nitflex
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.sharp.SkipNext
 import androidx.compose.material.icons.sharp.Speed
 import androidx.compose.material.icons.sharp.Subtitles
-import androidx.compose.material3.*
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -17,7 +29,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.theoplayer.android.api.THEOplayerConfig
 import com.theoplayer.android.api.source.SourceDescription
-import com.theoplayer.android.ui.*
+import com.theoplayer.android.ui.CurrentTimeDisplay
+import com.theoplayer.android.ui.ErrorDisplay
+import com.theoplayer.android.ui.FullscreenButton
+import com.theoplayer.android.ui.LanguageMenu
+import com.theoplayer.android.ui.LoadingSpinner
+import com.theoplayer.android.ui.PlaybackRateMenu
+import com.theoplayer.android.ui.UIController
 import com.theoplayer.android.ui.demo.nitflex.theme.NitflexTheme
 
 @Composable
@@ -33,14 +51,12 @@ fun NitflexUI(
             config = config,
             source = source,
             centerOverlay = {
-                val state = Player.current
-                if (state?.firstPlay == true) {
+                if (player.firstPlay) {
                     LoadingSpinner()
                 }
             },
             topChrome = {
-                val state = Player.current
-                if (state?.firstPlay == true) {
+                if (player.firstPlay) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.Center,
@@ -58,12 +74,11 @@ fun NitflexUI(
                 }
             },
             centerChrome = {
-                val state = Player.current
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly
                 ) {
-                    if (state?.firstPlay == true) {
+                    if (player.firstPlay) {
                         NitflexSeekButton(
                             seekOffset = -10,
                             iconSize = 48.dp,
@@ -74,7 +89,7 @@ fun NitflexUI(
                         iconModifier = Modifier.size(48.dp),
                         contentPadding = PaddingValues(8.dp)
                     )
-                    if (state?.firstPlay == true) {
+                    if (player.firstPlay) {
                         NitflexSeekButton(
                             seekOffset = 10,
                             iconSize = 48.dp,
@@ -84,8 +99,7 @@ fun NitflexUI(
                 }
             },
             bottomChrome = {
-                val state = Player.current
-                if (state?.firstPlay == true) {
+                if (player.firstPlay) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         verticalAlignment = Alignment.CenterVertically
@@ -135,11 +149,10 @@ fun NitflexUI(
                 }
             },
             errorOverlay = {
-                val state = Player.current
                 Box(contentAlignment = Alignment.Center) {
                     ErrorDisplay()
                     // Ensure the user can still exit fullscreen
-                    if (state?.fullscreen == true) {
+                    if (player.fullscreen) {
                         FullscreenButton(modifier = Modifier.align(Alignment.BottomEnd))
                     }
                 }

--- a/app/src/main/java/com/theoplayer/android/ui/demo/nitflex/NitflexUI.kt
+++ b/app/src/main/java/com/theoplayer/android/ui/demo/nitflex/NitflexUI.kt
@@ -33,13 +33,13 @@ fun NitflexUI(
             config = config,
             source = source,
             centerOverlay = {
-                val state = PlayerState.current
+                val state = Player.current
                 if (state?.firstPlay == true) {
                     LoadingSpinner()
                 }
             },
             topChrome = {
-                val state = PlayerState.current
+                val state = Player.current
                 if (state?.firstPlay == true) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
@@ -58,7 +58,7 @@ fun NitflexUI(
                 }
             },
             centerChrome = {
-                val state = PlayerState.current
+                val state = Player.current
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly
@@ -84,7 +84,7 @@ fun NitflexUI(
                 }
             },
             bottomChrome = {
-                val state = PlayerState.current
+                val state = Player.current
                 if (state?.firstPlay == true) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
@@ -135,7 +135,7 @@ fun NitflexUI(
                 }
             },
             errorOverlay = {
-                val state = PlayerState.current
+                val state = Player.current
                 Box(contentAlignment = Alignment.Center) {
                     ErrorDisplay()
                     // Ensure the user can still exit fullscreen

--- a/app/src/main/java/com/theoplayer/android/ui/demo/nitflex/NitflexUI.kt
+++ b/app/src/main/java/com/theoplayer/android/ui/demo/nitflex/NitflexUI.kt
@@ -39,7 +39,7 @@ import com.theoplayer.android.ui.PlaybackRateMenu
 import com.theoplayer.android.ui.Player
 import com.theoplayer.android.ui.UIController
 import com.theoplayer.android.ui.demo.nitflex.theme.NitflexTheme
-import com.theoplayer.android.ui.rememberTHEOplayer
+import com.theoplayer.android.ui.rememberPlayer
 
 @Composable
 fun NitflexUI(
@@ -48,7 +48,7 @@ fun NitflexUI(
     source: SourceDescription? = null,
     title: String? = null
 ) {
-    val player = rememberTHEOplayer(config)
+    val player = rememberPlayer(config)
     LaunchedEffect(key1 = player, key2 = source) {
         player.player?.source = source
     }
@@ -59,7 +59,7 @@ fun NitflexUI(
 @Composable
 fun NitflexUI(
     modifier: Modifier = Modifier,
-    player: Player = rememberTHEOplayer(),
+    player: Player = rememberPlayer(),
     title: String? = null
 ) {
     ProvideTextStyle(value = TextStyle(color = Color.White)) {

--- a/app/src/main/java/com/theoplayer/android/ui/demo/nitflex/NitflexUI.kt
+++ b/app/src/main/java/com/theoplayer/android/ui/demo/nitflex/NitflexUI.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -35,8 +36,10 @@ import com.theoplayer.android.ui.FullscreenButton
 import com.theoplayer.android.ui.LanguageMenu
 import com.theoplayer.android.ui.LoadingSpinner
 import com.theoplayer.android.ui.PlaybackRateMenu
+import com.theoplayer.android.ui.Player
 import com.theoplayer.android.ui.UIController
 import com.theoplayer.android.ui.demo.nitflex.theme.NitflexTheme
+import com.theoplayer.android.ui.rememberTHEOplayer
 
 @Composable
 fun NitflexUI(
@@ -45,11 +48,24 @@ fun NitflexUI(
     source: SourceDescription? = null,
     title: String? = null
 ) {
+    val player = rememberTHEOplayer(config)
+    LaunchedEffect(key1 = player, key2 = source) {
+        player.player?.source = source
+    }
+
+    NitflexUI(modifier = modifier, player = player, title = title)
+}
+
+@Composable
+fun NitflexUI(
+    modifier: Modifier = Modifier,
+    player: Player = rememberTHEOplayer(),
+    title: String? = null
+) {
     ProvideTextStyle(value = TextStyle(color = Color.White)) {
         UIController(
             modifier = modifier,
-            config = config,
-            source = source,
+            player = player,
             centerOverlay = {
                 if (player.firstPlay) {
                     LoadingSpinner()

--- a/docs/guides/custom-ui.md
+++ b/docs/guides/custom-ui.md
@@ -69,7 +69,7 @@ Additionally, we change the size and padding of the play button, to make it bigg
 
 You might have noticed that all buttons are visible immediately, even before the video starts playing for the first time. Most of the time however, you want to initially show only the play button, and then show the rest of the buttons after the video has started playing. To do this, you should check the player's current state and then adjust your player layout accordingly.
 
-Within any of the composable lambdas you pass to `UIController`, you can use `PlayerState.current` to access the player's current state. This `PlayerState` object exposes properties for the player's current time, duration, paused and muted states, etc. See [`PlayerState.kt`](../../ui/src/main/java/com/theoplayer/android/ui/PlayerState.kt) for the full list of properties.
+Within any of the composable lambdas you pass to `UIController`, you can use `Player.current` to access the current player. This `Player` object exposes properties for the player's current time, duration, paused and muted states, etc. See [`Player.kt`](../../ui/src/main/java/com/theoplayer/android/ui/Player.kt) for the full list of properties.
 
 You can then perform any logic on these properties to adjust your player layout. For example, you can check the `firstPlay` property to see if the player has already started playing for the first time, and only show certain buttons if that property is `true`:
 
@@ -86,7 +86,7 @@ setContent {
         },
         bottomChrome = {
             // Retrieve the player's state
-            val state = PlayerState.current
+            val state = Player.current
             // Show the bottom control bar only if we have already started playing before
             if (state?.firstPlay == true) {
                 SeekBar()
@@ -102,14 +102,14 @@ setContent {
 }
 ```
 
-All of the `PlayerState` properties are backed by an observable [`State`](https://developer.android.com/reference/kotlin/androidx/compose/runtime/State), so composables that read these properties will automatically re-compose whenever that property changes. This means you don't need any extra logic to re-draw the bottom control bar whenever `firstPlay` changes from `false` to `true`. This also makes it easy to create your own custom player components. [See the Jetpack Compose documentation for more information.](https://developer.android.com/jetpack/compose/state)
+All of the `Player` properties are backed by an observable [`State`](https://developer.android.com/reference/kotlin/androidx/compose/runtime/State), so composables that read these properties will automatically re-compose whenever that property changes. This means you don't need any extra logic to re-draw the bottom control bar whenever `firstPlay` changes from `false` to `true`. This also makes it easy to create your own custom player components. [See the Jetpack Compose documentation for more information.](https://developer.android.com/jetpack/compose/state)
 
 ```kotlin
 @Composable
 fun MyCurrentTimeDisplay(
 ) {
-    val state = PlayerState.current
-    val currentTime = state?.currentTime ?: 0.0
+    val player = Player.current
+    val currentTime = player?.currentTime ?: 0.0
     // This text will automatically update whenever the current time changes
     Text(text = currentTime.toString())
 }

--- a/ui/src/main/java/com/theoplayer/android/ui/AudioTrackList.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/AudioTrackList.kt
@@ -22,9 +22,9 @@ fun AudioTrackList(
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null
 ) {
-    val state = Player.current
-    val audioTracks = state?.audioTracks ?: listOf()
-    val activeAudioTrack = state?.activeAudioTrack
+    val player = Player.current
+    val audioTracks = player?.audioTracks ?: listOf()
+    val activeAudioTrack = player?.activeAudioTrack
     LazyColumn(modifier = modifier) {
         items(
             count = audioTracks.size,
@@ -40,7 +40,7 @@ fun AudioTrackList(
                     )
                 },
                 modifier = Modifier.clickable(onClick = {
-                    state?.activeAudioTrack = audioTrack
+                    player?.activeAudioTrack = audioTrack
                     onClick?.let { it() }
                 })
             )

--- a/ui/src/main/java/com/theoplayer/android/ui/AudioTrackList.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/AudioTrackList.kt
@@ -22,7 +22,7 @@ fun AudioTrackList(
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     val audioTracks = state?.audioTracks ?: listOf()
     val activeAudioTrack = state?.activeAudioTrack
     LazyColumn(modifier = modifier) {

--- a/ui/src/main/java/com/theoplayer/android/ui/ChromecastButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/ChromecastButton.kt
@@ -47,7 +47,7 @@ fun ChromecastButton(
         )
     }
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     val castState = state?.castState ?: PlayerCastState.UNAVAILABLE
     if (castState == PlayerCastState.UNAVAILABLE) {
         // Hide when Chromecast is not available

--- a/ui/src/main/java/com/theoplayer/android/ui/ChromecastButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/ChromecastButton.kt
@@ -47,8 +47,8 @@ fun ChromecastButton(
         )
     }
 ) {
-    val state = Player.current
-    val castState = state?.castState ?: PlayerCastState.UNAVAILABLE
+    val player = Player.current
+    val castState = player?.castState ?: PlayerCastState.UNAVAILABLE
     if (castState == PlayerCastState.UNAVAILABLE) {
         // Hide when Chromecast is not available
         return
@@ -58,7 +58,7 @@ fun ChromecastButton(
         modifier = modifier,
         contentPadding = contentPadding,
         onClick = {
-            state?.cast?.chromecast?.let {
+            player?.cast?.chromecast?.let {
                 if (it.isCasting) {
                     it.stop()
                 } else {
@@ -66,7 +66,7 @@ fun ChromecastButton(
                 }
             }
         }) {
-        when (state?.castState) {
+        when (player?.castState) {
             PlayerCastState.AVAILABLE -> availableIcon()
             PlayerCastState.CONNECTING -> connectingIcon()
             PlayerCastState.CONNECTED -> connectedIcon()

--- a/ui/src/main/java/com/theoplayer/android/ui/ChromecastDisplay.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/ChromecastDisplay.kt
@@ -25,8 +25,8 @@ import com.theoplayer.android.api.cast.chromecast.PlayerCastState
 fun ChromecastDisplay(
     modifier: Modifier = Modifier
 ) {
-    val state = Player.current
-    if (state?.castState != PlayerCastState.CONNECTED) {
+    val player = Player.current
+    if (player?.castState != PlayerCastState.CONNECTED) {
         // Hide when not connected to Chromecast
         return
     }
@@ -48,8 +48,8 @@ fun ChromecastDisplay(
 fun ChromecastDisplayCompact(
     modifier: Modifier = Modifier
 ) {
-    val state = Player.current
-    if (state?.castState != PlayerCastState.CONNECTED) {
+    val player = Player.current
+    if (player?.castState != PlayerCastState.CONNECTED) {
         // Hide when not connected to Chromecast
         return
     }
@@ -63,7 +63,7 @@ fun ChromecastDisplayCompact(
         )
         Spacer(Modifier.size(ButtonDefaults.IconSpacing))
         Text(
-            text = "Playing on ${state.castReceiverName ?: "Chromecast"}"
+            text = "Playing on ${player.castReceiverName ?: "Chromecast"}"
         )
     }
 }
@@ -77,8 +77,8 @@ fun ChromecastDisplayCompact(
 fun ChromecastDisplayExpanded(
     modifier: Modifier = Modifier
 ) {
-    val state = Player.current
-    if (state?.castState != PlayerCastState.CONNECTED) {
+    val player = Player.current
+    if (player?.castState != PlayerCastState.CONNECTED) {
         // Hide when not connected to Chromecast
         return
     }
@@ -100,7 +100,7 @@ fun ChromecastDisplayExpanded(
                 style = MaterialTheme.typography.bodyLarge
             )
             Text(
-                text = state.castReceiverName ?: "Chromecast",
+                text = player.castReceiverName ?: "Chromecast",
                 style = MaterialTheme.typography.headlineSmall
             )
         }

--- a/ui/src/main/java/com/theoplayer/android/ui/ChromecastDisplay.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/ChromecastDisplay.kt
@@ -25,7 +25,7 @@ import com.theoplayer.android.api.cast.chromecast.PlayerCastState
 fun ChromecastDisplay(
     modifier: Modifier = Modifier
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     if (state?.castState != PlayerCastState.CONNECTED) {
         // Hide when not connected to Chromecast
         return
@@ -48,7 +48,7 @@ fun ChromecastDisplay(
 fun ChromecastDisplayCompact(
     modifier: Modifier = Modifier
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     if (state?.castState != PlayerCastState.CONNECTED) {
         // Hide when not connected to Chromecast
         return
@@ -77,7 +77,7 @@ fun ChromecastDisplayCompact(
 fun ChromecastDisplayExpanded(
     modifier: Modifier = Modifier
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     if (state?.castState != PlayerCastState.CONNECTED) {
         // Hide when not connected to Chromecast
         return

--- a/ui/src/main/java/com/theoplayer/android/ui/CurrentTimeDisplay.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/CurrentTimeDisplay.kt
@@ -19,9 +19,9 @@ fun CurrentTimeDisplay(
     showRemaining: Boolean = false,
     showDuration: Boolean = false,
 ) {
-    val state = Player.current
-    val currentTime = state?.currentTime ?: 0.0
-    val duration = state?.duration ?: Double.NaN
+    val player = Player.current
+    val currentTime = player?.currentTime ?: 0.0
+    val duration = player?.duration ?: Double.NaN
 
     val time = if (showRemaining) {
         -(duration - currentTime)

--- a/ui/src/main/java/com/theoplayer/android/ui/CurrentTimeDisplay.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/CurrentTimeDisplay.kt
@@ -19,7 +19,7 @@ fun CurrentTimeDisplay(
     showRemaining: Boolean = false,
     showDuration: Boolean = false,
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     val currentTime = state?.currentTime ?: 0.0
     val duration = state?.duration ?: Double.NaN
 

--- a/ui/src/main/java/com/theoplayer/android/ui/DefaultUI.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/DefaultUI.kt
@@ -1,6 +1,11 @@
 package com.theoplayer.android.ui
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -40,14 +45,12 @@ fun DefaultUI(
         config = config,
         source = source,
         centerOverlay = {
-            val state = Player.current
-            if (state?.firstPlay == true) {
+            if (player.firstPlay) {
                 LoadingSpinner()
             }
         },
         topChrome = {
-            val state = Player.current
-            if (state?.firstPlay == true) {
+            if (player.firstPlay) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     title?.let {
                         Text(
@@ -62,20 +65,18 @@ fun DefaultUI(
             }
         },
         centerChrome = {
-            val state = Player.current
-            if (state?.firstPlay == true) {
+            if (player.firstPlay) {
                 SeekButton(seekOffset = -10, iconSize = 48.dp, contentPadding = PaddingValues(8.dp))
             }
             PlayButton(iconModifier = Modifier.size(96.dp), contentPadding = PaddingValues(8.dp))
-            if (state?.firstPlay == true) {
+            if (player.firstPlay) {
                 SeekButton(seekOffset = 10, iconSize = 48.dp, contentPadding = PaddingValues(8.dp))
             }
         },
         bottomChrome = {
-            val state = Player.current
-            if (state?.firstPlay == true) {
+            if (player.firstPlay) {
                 ChromecastDisplay(modifier = Modifier.padding(8.dp))
-                if (state.streamType != StreamType.Live) {
+                if (player.streamType != StreamType.Live) {
                     SeekBar()
                 }
                 Row(verticalAlignment = Alignment.CenterVertically) {
@@ -88,11 +89,10 @@ fun DefaultUI(
             }
         },
         errorOverlay = {
-            val state = Player.current
             Box(contentAlignment = Alignment.Center) {
                 ErrorDisplay()
                 // Ensure the user can still exit fullscreen
-                if (state?.fullscreen == true) {
+                if (player.fullscreen) {
                     FullscreenButton(modifier = Modifier.align(Alignment.BottomEnd))
                 }
             }

--- a/ui/src/main/java/com/theoplayer/android/ui/DefaultUI.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/DefaultUI.kt
@@ -41,7 +41,7 @@ fun DefaultUI(
     source: SourceDescription? = null,
     title: String? = null
 ) {
-    val player = rememberTHEOplayer(config)
+    val player = rememberPlayer(config)
     LaunchedEffect(key1 = player, key2 = source) {
         player.player?.source = source
     }
@@ -61,14 +61,14 @@ fun DefaultUI(
  * a [UIController].
  *
  * @param modifier the [Modifier] to be applied to this UI
- * @param player the player. This should always be created using [rememberTHEOplayer].
+ * @param player the player. This should always be created using [rememberPlayer].
  * @param title the stream's title, shown at the top of the player
  * @see UIController
  */
 @Composable
 fun DefaultUI(
     modifier: Modifier = Modifier,
-    player: Player = rememberTHEOplayer(),
+    player: Player = rememberPlayer(),
     title: String? = null
 ) {
     UIController(

--- a/ui/src/main/java/com/theoplayer/android/ui/DefaultUI.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/DefaultUI.kt
@@ -40,13 +40,13 @@ fun DefaultUI(
         config = config,
         source = source,
         centerOverlay = {
-            val state = PlayerState.current
+            val state = Player.current
             if (state?.firstPlay == true) {
                 LoadingSpinner()
             }
         },
         topChrome = {
-            val state = PlayerState.current
+            val state = Player.current
             if (state?.firstPlay == true) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     title?.let {
@@ -62,7 +62,7 @@ fun DefaultUI(
             }
         },
         centerChrome = {
-            val state = PlayerState.current
+            val state = Player.current
             if (state?.firstPlay == true) {
                 SeekButton(seekOffset = -10, iconSize = 48.dp, contentPadding = PaddingValues(8.dp))
             }
@@ -72,7 +72,7 @@ fun DefaultUI(
             }
         },
         bottomChrome = {
-            val state = PlayerState.current
+            val state = Player.current
             if (state?.firstPlay == true) {
                 ChromecastDisplay(modifier = Modifier.padding(8.dp))
                 if (state.streamType != StreamType.Live) {
@@ -88,7 +88,7 @@ fun DefaultUI(
             }
         },
         errorOverlay = {
-            val state = PlayerState.current
+            val state = Player.current
             Box(contentAlignment = Alignment.Center) {
                 ErrorDisplay()
                 // Ensure the user can still exit fullscreen

--- a/ui/src/main/java/com/theoplayer/android/ui/DefaultUI.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/DefaultUI.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -40,10 +41,39 @@ fun DefaultUI(
     source: SourceDescription? = null,
     title: String? = null
 ) {
+    val player = rememberTHEOplayer(config)
+    LaunchedEffect(key1 = player, key2 = source) {
+        player.player?.source = source
+    }
+
+    DefaultUI(modifier = modifier, player = player, title = title)
+}
+
+/**
+ * A default THEOplayer UI component.
+ *
+ * This component provides a great player experience out-of-the-box, that works for all types
+ * of streams. It provides all the common playback controls for playing, seeking, changing
+ * languages and qualities.
+ *
+ * The colors and fonts can be changed by wrapping this inside a [THEOplayerTheme].
+ * For more extensive customizations, we recommend defining your own custom UI using
+ * a [UIController].
+ *
+ * @param modifier the [Modifier] to be applied to this UI
+ * @param player the player. This should always be created using [rememberTHEOplayer].
+ * @param title the stream's title, shown at the top of the player
+ * @see UIController
+ */
+@Composable
+fun DefaultUI(
+    modifier: Modifier = Modifier,
+    player: Player = rememberTHEOplayer(),
+    title: String? = null
+) {
     UIController(
         modifier = modifier,
-        config = config,
-        source = source,
+        player = player,
         centerOverlay = {
             if (player.firstPlay) {
                 LoadingSpinner()

--- a/ui/src/main/java/com/theoplayer/android/ui/DurationDisplay.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/DurationDisplay.kt
@@ -13,8 +13,8 @@ import androidx.compose.ui.Modifier
 fun DurationDisplay(
     modifier: Modifier = Modifier
 ) {
-    val state = Player.current
-    val duration = state?.duration ?: Double.NaN
+    val player = Player.current
+    val duration = player?.duration ?: Double.NaN
 
     Text(modifier = modifier, text = formatTime(duration))
 }

--- a/ui/src/main/java/com/theoplayer/android/ui/DurationDisplay.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/DurationDisplay.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Modifier
 fun DurationDisplay(
     modifier: Modifier = Modifier
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     val duration = state?.duration ?: Double.NaN
 
     Text(modifier = modifier, text = formatTime(duration))

--- a/ui/src/main/java/com/theoplayer/android/ui/ErrorDisplay.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/ErrorDisplay.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.unit.dp
 fun ErrorDisplay(
     modifier: Modifier = Modifier,
 ) {
-    val error = PlayerState.current?.error
+    val error = Player.current?.error
 
     error?.let { it ->
         Row(

--- a/ui/src/main/java/com/theoplayer/android/ui/FullscreenButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/FullscreenButton.kt
@@ -35,7 +35,7 @@ fun FullscreenButton(
         )
     }
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     IconButton(
         modifier = modifier,
         contentPadding = contentPadding,

--- a/ui/src/main/java/com/theoplayer/android/ui/FullscreenButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/FullscreenButton.kt
@@ -35,16 +35,16 @@ fun FullscreenButton(
         )
     }
 ) {
-    val state = Player.current
+    val player = Player.current
     IconButton(
         modifier = modifier,
         contentPadding = contentPadding,
         onClick = {
-            state?.let {
+            player?.let {
                 it.fullscreen = !it.fullscreen
             }
         }) {
-        if (state?.fullscreen == true) {
+        if (player?.fullscreen == true) {
             exit()
         } else {
             enter()

--- a/ui/src/main/java/com/theoplayer/android/ui/LanguageMenu.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/LanguageMenu.kt
@@ -31,7 +31,7 @@ fun MenuScope.LanguageMenu() {
         },
     ) {
         BoxWithConstraints {
-            val state = PlayerState.current
+            val state = Player.current
             val neededWidth =
                 (if (showAudioTracks(state)) 300.dp else 0.dp) +
                         (if (showSubtitleTracks(state)) 300.dp else 0.dp)
@@ -44,11 +44,11 @@ fun MenuScope.LanguageMenu() {
     }
 }
 
-private fun showAudioTracks(state: PlayerState?): Boolean {
+private fun showAudioTracks(state: Player?): Boolean {
     return state != null && state.audioTracks.size >= 2
 }
 
-private fun showSubtitleTracks(state: PlayerState?): Boolean {
+private fun showSubtitleTracks(state: Player?): Boolean {
     return state != null && state.subtitleTracks.isNotEmpty()
 }
 
@@ -63,7 +63,7 @@ private fun showSubtitleTracks(state: PlayerState?): Boolean {
  */
 @Composable
 fun MenuScope.LanguageMenuCompact() {
-    val state = PlayerState.current
+    val state = Player.current
     Column(modifier = Modifier.padding(horizontal = 16.dp)) {
         if (showAudioTracks(state)) {
             Row {
@@ -130,7 +130,7 @@ fun MenuScope.LanguageMenuCompact() {
  */
 @Composable
 fun MenuScope.LanguageMenuExpanded() {
-    val state = PlayerState.current
+    val state = Player.current
     Row(modifier = Modifier.padding(horizontal = 16.dp)) {
         if (showAudioTracks(state)) {
             Column(modifier = Modifier.weight(1f)) {

--- a/ui/src/main/java/com/theoplayer/android/ui/LanguageMenu.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/LanguageMenu.kt
@@ -31,10 +31,10 @@ fun MenuScope.LanguageMenu() {
         },
     ) {
         BoxWithConstraints {
-            val state = Player.current
+            val player = Player.current
             val neededWidth =
-                (if (showAudioTracks(state)) 300.dp else 0.dp) +
-                        (if (showSubtitleTracks(state)) 300.dp else 0.dp)
+                (if (showAudioTracks(player)) 300.dp else 0.dp) +
+                        (if (showSubtitleTracks(player)) 300.dp else 0.dp)
             if (maxWidth < neededWidth) {
                 LanguageMenuCompact()
             } else {
@@ -44,12 +44,12 @@ fun MenuScope.LanguageMenu() {
     }
 }
 
-private fun showAudioTracks(state: Player?): Boolean {
-    return state != null && state.audioTracks.size >= 2
+private fun showAudioTracks(player: Player?): Boolean {
+    return player != null && player.audioTracks.size >= 2
 }
 
-private fun showSubtitleTracks(state: Player?): Boolean {
-    return state != null && state.subtitleTracks.isNotEmpty()
+private fun showSubtitleTracks(player: Player?): Boolean {
+    return player != null && player.subtitleTracks.isNotEmpty()
 }
 
 /**
@@ -63,9 +63,9 @@ private fun showSubtitleTracks(state: Player?): Boolean {
  */
 @Composable
 fun MenuScope.LanguageMenuCompact() {
-    val state = Player.current
+    val player = Player.current
     Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-        if (showAudioTracks(state)) {
+        if (showAudioTracks(player)) {
             Row {
                 Text(
                     modifier = Modifier
@@ -81,7 +81,7 @@ fun MenuScope.LanguageMenuCompact() {
                 ) {
                     Text(
                         modifier = Modifier.weight(1f),
-                        text = state?.activeAudioTrack?.let { formatTrackLabel(it) } ?: "None",
+                        text = player?.activeAudioTrack?.let { formatTrackLabel(it) } ?: "None",
                         textAlign = TextAlign.Center
                     )
                     Icon(
@@ -91,7 +91,7 @@ fun MenuScope.LanguageMenuCompact() {
                 }
             }
         }
-        if (showSubtitleTracks(state)) {
+        if (showSubtitleTracks(player)) {
             Row {
                 Text(
                     modifier = Modifier
@@ -107,7 +107,7 @@ fun MenuScope.LanguageMenuCompact() {
                 ) {
                     Text(
                         modifier = Modifier.weight(1f),
-                        text = state?.activeSubtitleTrack?.let { formatTrackLabel(it) } ?: "Off",
+                        text = player?.activeSubtitleTrack?.let { formatTrackLabel(it) } ?: "Off",
                         textAlign = TextAlign.Center
                     )
                     Icon(
@@ -130,9 +130,9 @@ fun MenuScope.LanguageMenuCompact() {
  */
 @Composable
 fun MenuScope.LanguageMenuExpanded() {
-    val state = Player.current
+    val player = Player.current
     Row(modifier = Modifier.padding(horizontal = 16.dp)) {
-        if (showAudioTracks(state)) {
+        if (showAudioTracks(player)) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     modifier = Modifier
@@ -145,7 +145,7 @@ fun MenuScope.LanguageMenuExpanded() {
                 AudioTrackList()
             }
         }
-        if (showSubtitleTracks(state)) {
+        if (showSubtitleTracks(player)) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     modifier = Modifier

--- a/ui/src/main/java/com/theoplayer/android/ui/LiveButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/LiveButton.kt
@@ -52,16 +52,16 @@ fun LiveButton(
         Text(text = " LIVE")
     }
 ) {
-    val state = Player.current
-    if (state?.streamType == StreamType.Live || state?.streamType == StreamType.Dvr) {
+    val player = Player.current
+    if (player?.streamType == StreamType.Live || player?.streamType == StreamType.Dvr) {
         val isLive =
-            !state.paused && ((state.seekable.lastEnd ?: 0.0) - state.currentTime) <= liveThreshold
+            !player.paused && ((player.seekable.lastEnd ?: 0.0) - player.currentTime) <= liveThreshold
         TextButton(
             modifier = modifier,
             contentPadding = contentPadding,
             colors = colors,
             onClick = {
-                state.player?.let {
+                player.player?.let {
                     it.currentTime = Double.POSITIVE_INFINITY
                     it.play()
                 }

--- a/ui/src/main/java/com/theoplayer/android/ui/LiveButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/LiveButton.kt
@@ -52,7 +52,7 @@ fun LiveButton(
         Text(text = " LIVE")
     }
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     if (state?.streamType == StreamType.Live || state?.streamType == StreamType.Dvr) {
         val isLive =
             !state.paused && ((state.seekable.lastEnd ?: 0.0) - state.currentTime) <= liveThreshold

--- a/ui/src/main/java/com/theoplayer/android/ui/LoadingSpinner.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/LoadingSpinner.kt
@@ -30,8 +30,8 @@ fun LoadingSpinner(
     strokeWidth: Dp = ProgressIndicatorDefaults.CircularStrokeWidth,
     delay: Duration = 500.milliseconds
 ) {
-    val state = Player.current
-    val loading = state?.loading ?: false
+    val player = Player.current
+    val loading = player?.loading ?: false
     AnimatedVisibility(
         visible = loading,
         // Show the loading spinner only after a small delay

--- a/ui/src/main/java/com/theoplayer/android/ui/LoadingSpinner.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/LoadingSpinner.kt
@@ -30,7 +30,7 @@ fun LoadingSpinner(
     strokeWidth: Dp = ProgressIndicatorDefaults.CircularStrokeWidth,
     delay: Duration = 500.milliseconds
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     val loading = state?.loading ?: false
     AnimatedVisibility(
         visible = loading,

--- a/ui/src/main/java/com/theoplayer/android/ui/MuteButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/MuteButton.kt
@@ -35,16 +35,16 @@ fun MuteButton(
         )
     }
 ) {
-    val state = Player.current
+    val player = Player.current
     IconButton(
         modifier = modifier,
         contentPadding = contentPadding,
         onClick = {
-            state?.let {
+            player?.let {
                 it.muted = !it.muted
             }
         }) {
-        if (state?.muted == true) {
+        if (player?.muted == true) {
             unmute()
         } else {
             mute()

--- a/ui/src/main/java/com/theoplayer/android/ui/MuteButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/MuteButton.kt
@@ -35,7 +35,7 @@ fun MuteButton(
         )
     }
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     IconButton(
         modifier = modifier,
         contentPadding = contentPadding,

--- a/ui/src/main/java/com/theoplayer/android/ui/PlayButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/PlayButton.kt
@@ -47,12 +47,12 @@ fun PlayButton(
         )
     }
 ) {
-    val state = Player.current
+    val player = Player.current
     IconButton(
         modifier = modifier,
         contentPadding = contentPadding,
         onClick = {
-            state?.let {
+            player?.let {
                 if (it.paused) {
                     it.player?.play()
                 } else {
@@ -60,11 +60,11 @@ fun PlayButton(
                 }
             }
         }) {
-        if (state == null) {
+        if (player == null) {
             play()
-        } else if (!state.paused) {
+        } else if (!player.paused) {
             pause()
-        } else if (state.ended) {
+        } else if (player.ended) {
             replay()
         } else {
             play()

--- a/ui/src/main/java/com/theoplayer/android/ui/PlayButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/PlayButton.kt
@@ -47,7 +47,7 @@ fun PlayButton(
         )
     }
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     IconButton(
         modifier = modifier,
         contentPadding = contentPadding,

--- a/ui/src/main/java/com/theoplayer/android/ui/PlaybackRateList.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/PlaybackRateList.kt
@@ -24,7 +24,7 @@ fun PlaybackRateList(
     playbackRates: List<Double> = listOf(0.25, 0.5, 1.0, 1.25, 1.5, 2.0),
     onClick: (() -> Unit)? = null
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     val currentPlaybackRate = state?.playbackRate ?: 1
     LazyColumn(modifier = modifier) {
         items(

--- a/ui/src/main/java/com/theoplayer/android/ui/PlaybackRateList.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/PlaybackRateList.kt
@@ -24,8 +24,8 @@ fun PlaybackRateList(
     playbackRates: List<Double> = listOf(0.25, 0.5, 1.0, 1.25, 1.5, 2.0),
     onClick: (() -> Unit)? = null
 ) {
-    val state = Player.current
-    val currentPlaybackRate = state?.playbackRate ?: 1
+    val player = Player.current
+    val currentPlaybackRate = player?.playbackRate ?: 1
     LazyColumn(modifier = modifier) {
         items(
             count = playbackRates.size,
@@ -41,7 +41,7 @@ fun PlaybackRateList(
                     )
                 },
                 modifier = Modifier.clickable(onClick = {
-                    state?.playbackRate = playbackRate
+                    player?.playbackRate = playbackRate
                     onClick?.let { it() }
                 })
             )

--- a/ui/src/main/java/com/theoplayer/android/ui/Player.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/Player.kt
@@ -260,13 +260,13 @@ enum class StreamType {
  */
 @Composable
 internal fun rememberPlayerState(theoplayerView: THEOplayerView?): Player {
-    val state = remember(theoplayerView) { PlayerImpl(theoplayerView) }
-    DisposableEffect(state) {
+    val player = remember(theoplayerView) { PlayerImpl(theoplayerView) }
+    DisposableEffect(player) {
         onDispose {
-            state.dispose()
+            player.dispose()
         }
     }
-    return state
+    return player
 }
 
 private class PlayerImpl(override val theoplayerView: THEOplayerView?) : Player {

--- a/ui/src/main/java/com/theoplayer/android/ui/Player.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/Player.kt
@@ -255,21 +255,7 @@ enum class StreamType {
     Dvr
 }
 
-/**
- * Creates and remembers a [Player] that tracks the state of the given [theoplayerView]'s player.
- */
-@Composable
-internal fun rememberPlayerState(theoplayerView: THEOplayerView?): Player {
-    val player = remember(theoplayerView) { PlayerImpl(theoplayerView) }
-    DisposableEffect(player) {
-        onDispose {
-            player.dispose()
-        }
-    }
-    return player
-}
-
-private class PlayerImpl(override val theoplayerView: THEOplayerView?) : Player {
+internal class PlayerImpl(override val theoplayerView: THEOplayerView?) : Player {
     override val player = theoplayerView?.player
     override val cast = theoplayerView?.cast
     override var currentTime by mutableStateOf(0.0)

--- a/ui/src/main/java/com/theoplayer/android/ui/PlayerState.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/PlayerState.kt
@@ -55,6 +55,13 @@ interface PlayerState {
     val player: Player?
 
     /**
+     * Returns the wrapped THEOplayer view.
+     *
+     * *DO NOT* use this view directly! It will be managed by a [UIController] or [DefaultUI].
+     */
+    val theoplayerView: THEOplayerView?
+
+    /**
      * Returns the raw [Cast] API of the backing THEOplayer instance.
      */
     val cast: Cast?
@@ -231,7 +238,7 @@ enum class StreamType {
  * Creates and remembers a [PlayerState] that tracks the state of the given [theoplayerView]'s player.
  */
 @Composable
-fun rememberPlayerState(theoplayerView: THEOplayerView?): PlayerState {
+internal fun rememberPlayerState(theoplayerView: THEOplayerView?): PlayerState {
     val state = remember(theoplayerView) { PlayerStateImpl(theoplayerView) }
     DisposableEffect(state) {
         onDispose {
@@ -241,7 +248,7 @@ fun rememberPlayerState(theoplayerView: THEOplayerView?): PlayerState {
     return state
 }
 
-private class PlayerStateImpl(private val theoplayerView: THEOplayerView?) : PlayerState {
+private class PlayerStateImpl(override val theoplayerView: THEOplayerView?) : PlayerState {
     override val player = theoplayerView?.player
     override val cast = theoplayerView?.cast
     override var currentTime by mutableStateOf(0.0)

--- a/ui/src/main/java/com/theoplayer/android/ui/QualityList.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/QualityList.kt
@@ -22,7 +22,7 @@ fun QualityList(
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     val videoQualities = state?.videoQualities ?: listOf()
     val targetVideoQuality = state?.targetVideoQuality
     LazyColumn(modifier = modifier) {

--- a/ui/src/main/java/com/theoplayer/android/ui/QualityList.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/QualityList.kt
@@ -22,9 +22,9 @@ fun QualityList(
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null
 ) {
-    val state = Player.current
-    val videoQualities = state?.videoQualities ?: listOf()
-    val targetVideoQuality = state?.targetVideoQuality
+    val player = Player.current
+    val videoQualities = player?.videoQualities ?: listOf()
+    val targetVideoQuality = player?.targetVideoQuality
     LazyColumn(modifier = modifier) {
         item(key = null) {
             ListItem(
@@ -36,7 +36,7 @@ fun QualityList(
                     )
                 },
                 modifier = Modifier.clickable(onClick = {
-                    state?.targetVideoQuality = null
+                    player?.targetVideoQuality = null
                     onClick?.let { it() }
                 })
             )
@@ -56,7 +56,7 @@ fun QualityList(
                     )
                 },
                 modifier = Modifier.clickable(onClick = {
-                    state?.targetVideoQuality = quality
+                    player?.targetVideoQuality = quality
                     onClick?.let { it() }
                 })
             )

--- a/ui/src/main/java/com/theoplayer/android/ui/SeekBar.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SeekBar.kt
@@ -20,9 +20,9 @@ fun SeekBar(
     modifier: Modifier = Modifier,
     colors: SliderColors = SliderDefaults.colors()
 ) {
-    val state = Player.current
-    val currentTime = state?.currentTime?.toFloat() ?: 0.0f
-    val seekable = state?.seekable ?: TimeRanges(listOf())
+    val player = Player.current
+    val currentTime = player?.currentTime?.toFloat() ?: 0.0f
+    val seekable = player?.seekable ?: TimeRanges(listOf())
     val valueRange = seekable.bounds ?: 0.0..0.0
 
     var seekTime by remember { mutableStateOf<Float?>(null) }
@@ -36,7 +36,7 @@ fun SeekBar(
         enabled = seekable.isNotEmpty(),
         onValueChange = { time ->
             seekTime = time
-            state?.player?.let {
+            player?.player?.let {
                 if (!it.isPaused) {
                     wasPlayingBeforeSeek = true
                     it.pause()
@@ -47,7 +47,7 @@ fun SeekBar(
         onValueChangeFinished = {
             seekTime = null
             if (wasPlayingBeforeSeek) {
-                state?.player?.play()
+                player?.player?.play()
                 wasPlayingBeforeSeek = false
             }
         }

--- a/ui/src/main/java/com/theoplayer/android/ui/SeekBar.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SeekBar.kt
@@ -20,7 +20,7 @@ fun SeekBar(
     modifier: Modifier = Modifier,
     colors: SliderColors = SliderDefaults.colors()
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     val currentTime = state?.currentTime?.toFloat() ?: 0.0f
     val seekable = state?.seekable ?: TimeRanges(listOf())
     val valueRange = seekable.bounds ?: 0.0..0.0

--- a/ui/src/main/java/com/theoplayer/android/ui/SeekButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SeekButton.kt
@@ -82,12 +82,12 @@ fun SeekButton(
     contentPadding: PaddingValues = PaddingValues(0.dp),
     content: @Composable () -> Unit
 ) {
-    val state = Player.current
+    val player = Player.current
     IconButton(
         modifier = modifier,
         contentPadding = contentPadding,
         onClick = {
-            state?.player?.let {
+            player?.player?.let {
                 if (!it.duration.isNaN()) {
                     it.currentTime = (it.currentTime + seekOffset).coerceIn(0.0, it.duration)
                 }

--- a/ui/src/main/java/com/theoplayer/android/ui/SeekButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SeekButton.kt
@@ -82,7 +82,7 @@ fun SeekButton(
     contentPadding: PaddingValues = PaddingValues(0.dp),
     content: @Composable () -> Unit
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     IconButton(
         modifier = modifier,
         contentPadding = contentPadding,

--- a/ui/src/main/java/com/theoplayer/android/ui/SettingsMenu.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SettingsMenu.kt
@@ -32,7 +32,7 @@ fun MenuScope.SettingsMenu() {
             )
         },
     ) {
-        val state = PlayerState.current
+        val state = Player.current
         Column(modifier = Modifier.padding(horizontal = 16.dp)) {
             Row {
                 Text(

--- a/ui/src/main/java/com/theoplayer/android/ui/SettingsMenu.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SettingsMenu.kt
@@ -32,7 +32,7 @@ fun MenuScope.SettingsMenu() {
             )
         },
     ) {
-        val state = Player.current
+        val player = Player.current
         Column(modifier = Modifier.padding(horizontal = 16.dp)) {
             Row {
                 Text(
@@ -50,8 +50,8 @@ fun MenuScope.SettingsMenu() {
                     Text(
                         modifier = Modifier.weight(1f),
                         text = formatActiveQualityLabel(
-                            state?.targetVideoQuality,
-                            state?.activeVideoQuality
+                            player?.targetVideoQuality,
+                            player?.activeVideoQuality
                         ),
                         textAlign = TextAlign.Center
                     )
@@ -76,7 +76,7 @@ fun MenuScope.SettingsMenu() {
                 ) {
                     Text(
                         modifier = Modifier.weight(1f),
-                        text = formatPlaybackRate(state?.playbackRate ?: 1.0),
+                        text = formatPlaybackRate(player?.playbackRate ?: 1.0),
                         textAlign = TextAlign.Center
                     )
                     Icon(

--- a/ui/src/main/java/com/theoplayer/android/ui/SubtitleTrackList.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SubtitleTrackList.kt
@@ -22,9 +22,9 @@ fun SubtitleTrackList(
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null
 ) {
-    val state = Player.current
-    val subtitleTracks = state?.subtitleTracks ?: listOf()
-    val activeSubtitleTrack = state?.activeSubtitleTrack
+    val player = Player.current
+    val subtitleTracks = player?.subtitleTracks ?: listOf()
+    val activeSubtitleTrack = player?.activeSubtitleTrack
     LazyColumn(modifier = modifier) {
         item(key = null) {
             ListItem(
@@ -36,7 +36,7 @@ fun SubtitleTrackList(
                     )
                 },
                 modifier = Modifier.clickable(onClick = {
-                    state?.activeSubtitleTrack = null
+                    player?.activeSubtitleTrack = null
                     onClick?.let { it() }
                 })
             )
@@ -55,7 +55,7 @@ fun SubtitleTrackList(
                     )
                 },
                 modifier = Modifier.clickable(onClick = {
-                    state?.activeSubtitleTrack = audioTrack
+                    player?.activeSubtitleTrack = audioTrack
                     onClick?.let { it() }
                 })
             )

--- a/ui/src/main/java/com/theoplayer/android/ui/SubtitleTrackList.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SubtitleTrackList.kt
@@ -22,7 +22,7 @@ fun SubtitleTrackList(
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null
 ) {
-    val state = PlayerState.current
+    val state = Player.current
     val subtitleTracks = state?.subtitleTracks ?: listOf()
     val activeSubtitleTrack = state?.activeSubtitleTrack
     LazyColumn(modifier = modifier) {

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -67,7 +67,7 @@ fun UIController(
     bottomChrome: (@Composable UIControllerScope.() -> Unit)? = null
 ) {
     val player = rememberPlayer(config)
-    LaunchedEffect(key1 = player, key2 = source) {
+    LaunchedEffect(player, source) {
         player.player?.source = source
     }
 
@@ -120,7 +120,7 @@ fun UIController(
 ) {
     var tapCount by remember { mutableStateOf(0) }
     var isRecentlyTapped by remember { mutableStateOf(true) }
-    LaunchedEffect(key1 = tapCount) {
+    LaunchedEffect(tapCount) {
         isRecentlyTapped = true
         delay(2.seconds)
         isRecentlyTapped = false
@@ -408,14 +408,14 @@ internal fun rememberTHEOplayerView(config: THEOplayerConfig? = null): THEOplaye
     val context = LocalContext.current
     val theoplayerView = remember { THEOplayerView(context, config) }
 
-    DisposableEffect(key1 = theoplayerView) {
+    DisposableEffect(theoplayerView) {
         onDispose {
             theoplayerView.onDestroy()
         }
     }
 
     val lifecycle = LocalLifecycleOwner.current.lifecycle
-    DisposableEffect(key1 = lifecycle, key2 = theoplayerView) {
+    DisposableEffect(lifecycle, theoplayerView) {
         val lifecycleObserver = LifecycleEventObserver { _, event ->
             when (event) {
                 Lifecycle.Event.ON_RESUME -> theoplayerView.onResume()

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.*
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -35,7 +34,7 @@ private val controlsExitDuration = 500.milliseconds
  * A container component for a THEOplayer UI.
  *
  * This component provides a basic layout structure for a player UI,
- * and handles the creation and management of a [PlayerState] instance for this UI.
+ * and handles the creation and management of a [Player] instance for this UI.
  *
  * The colors and fonts can be changed by wrapping this inside a [THEOplayerTheme].
  *
@@ -111,7 +110,7 @@ fun UIController(
 @Composable
 fun UIController(
     modifier: Modifier = Modifier,
-    player: PlayerState = rememberTHEOplayer(),
+    player: Player = rememberTHEOplayer(),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     color: Color = Color.Black,
     centerOverlay: (@Composable UIControllerScope.() -> Unit)? = null,
@@ -171,7 +170,7 @@ fun UIController(
     )
 
     PlayerContainer(modifier = modifier, theoplayerView = player.theoplayerView) {
-        CompositionLocalProvider(LocalPlayerState provides player) {
+        CompositionLocalProvider(LocalPlayer provides player) {
             AnimatedContent(
                 modifier = Modifier
                     .background(background)
@@ -355,12 +354,12 @@ private fun UIControllerScope.PlayerControls(
 }
 
 /**
- * Creates and remembers a [PlayerState].
+ * Creates and remembers a [Player].
  *
  * @param config the player configuration
  */
 @Composable
-fun rememberTHEOplayer(config: THEOplayerConfig? = null): PlayerState {
+fun rememberTHEOplayer(config: THEOplayerConfig? = null): Player {
     val theoplayerView = if (LocalInspectionMode.current) {
         null
     } else {

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -66,7 +66,7 @@ fun UIController(
     centerChrome: (@Composable UIControllerScope.() -> Unit)? = null,
     bottomChrome: (@Composable UIControllerScope.() -> Unit)? = null
 ) {
-    val player = rememberTHEOplayer(config)
+    val player = rememberPlayer(config)
     LaunchedEffect(key1 = player, key2 = source) {
         player.player?.source = source
     }
@@ -92,7 +92,7 @@ fun UIController(
  * The colors and fonts can be changed by wrapping this inside a [THEOplayerTheme].
  *
  * @param modifier the [Modifier] to be applied to this container
- * @param player the player. This should always be created using [rememberTHEOplayer].
+ * @param player the player. This should always be created using [rememberPlayer].
  * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
  * for this container. You can create and pass in your own `remember`ed instance to observe
  * [Interaction]s and customize the behavior of this container.
@@ -109,7 +109,7 @@ fun UIController(
 @Composable
 fun UIController(
     modifier: Modifier = Modifier,
-    player: Player = rememberTHEOplayer(),
+    player: Player = rememberPlayer(),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     color: Color = Color.Black,
     centerOverlay: (@Composable UIControllerScope.() -> Unit)? = null,
@@ -381,7 +381,7 @@ private fun UIControllerScope.PlayerControls(
  * @param config the player configuration
  */
 @Composable
-fun rememberTHEOplayer(config: THEOplayerConfig? = null): Player {
+fun rememberPlayer(config: THEOplayerConfig? = null): Player {
     val theoplayerView = if (LocalInspectionMode.current) {
         null
     } else {

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -67,7 +67,6 @@ fun UIController(
     bottomChrome: (@Composable UIControllerScope.() -> Unit)? = null
 ) {
     val player = rememberTHEOplayer(config)
-
     LaunchedEffect(key1 = player, key2 = source) {
         player.player?.source = source
     }

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -387,7 +387,15 @@ fun rememberPlayer(config: THEOplayerConfig? = null): Player {
     } else {
         rememberTHEOplayerView(config)
     }
-    return rememberPlayerState(theoplayerView = theoplayerView)
+
+    val player = remember(theoplayerView) { PlayerImpl(theoplayerView) }
+    DisposableEffect(player) {
+        onDispose {
+            player.dispose()
+        }
+    }
+
+    return player
 }
 
 /**

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -140,7 +140,7 @@ fun UIController(
         }
     }
 
-    val scope = remember { UIControllerScopeImpl() }
+    val scope = remember(player) { UIControllerScopeImpl(player) }
 
     val uiState by remember {
         derivedStateOf {
@@ -239,9 +239,13 @@ fun UIController(
  * Scope for the contents of a [UIController].
  */
 interface UIControllerScope : MenuScope {
+    /**
+     * The player hosted in this [UIController].
+     */
+    val player: Player
 }
 
-private class UIControllerScopeImpl() :
+private class UIControllerScopeImpl(override val player: Player) :
     UIControllerScope {
     private var menuStack = mutableStateListOf<MenuContent>()
 


### PR DESCRIPTION
Unfortunately, our initial API is not powerful enough. Users want to be able to interact with a `PlayerState` *outside* of the scope of a `DefaultUI` or `UIController`, and they want to be able to wrap it to provide a custom API.

This PR extracts the construction of the `THEOplayerView` and its associated `PlayerState` into a public `rememberPlayer(config)` function, returning a `Player`. This `Player` can be passed directly to `DefaultUI` or `UIController`, which will then "host" the associated `THEOplayerView`.

A `Player` can now also be *moved* into a different UI without losing the player's state. This is shown in the demo app, where switching between the default theme and the Nitflex theme now retains the playback state.