### PR TITLE
Update FullscreenHandler.kt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * 🐛 Disable system gestures on the `SeekBar` component. ([#30](https://github.com/THEOplayer/android-ui/pull/30)) 
 * 🐛 Fixed ad clickthrough not working. ([#33](https://github.com/THEOplayer/android-ui/pull/33))
 * 🐛 Fixed UI not re-appearing after playing an ad. ([#33](https://github.com/THEOplayer/android-ui/pull/33))
+* 🐛 Fixed exiting fullscreen disabling [edge-to-edge display](https://developer.android.com/develop/ui/views/layout/edge-to-edge-manually). ([#32](https://github.com/THEOplayer/android-ui/pull/32))
 
 ## v1.7.0 (2024-08-12)
 

--- a/ui/src/main/java/com/theoplayer/android/ui/FullscreenHandler.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/FullscreenHandler.kt
@@ -35,7 +35,6 @@ internal class FullscreenHandlerImpl(private val view: View) : FullscreenHandler
         val window = activity.window
 
         // Hide system bars
-        WindowCompat.setDecorFitsSystemWindows(window, false)
         WindowCompat.getInsetsController(window, view).let { controller ->
             controller.hide(WindowInsetsCompat.Type.systemBars())
             previousSystemBarsBehavior = controller.systemBarsBehavior
@@ -74,7 +73,6 @@ internal class FullscreenHandlerImpl(private val view: View) : FullscreenHandler
         val window = activity.window
 
         // Restore system bars
-        WindowCompat.setDecorFitsSystemWindows(window, true)
         WindowCompat.getInsetsController(window, view).let { controller ->
             controller.show(WindowInsetsCompat.Type.systemBars())
             controller.systemBarsBehavior = previousSystemBarsBehavior


### PR DESCRIPTION
### Make fullScreen handler compatible with edge-to-edge.
Hello.
The current version of the full screen doesn't respect developer-selected edge-to-edge. If the developer enables the edge-to-edge feature, and then the end user goes to full screen and then returns, you force the system to ignore the edge-to-edge.
The before state is as follows:

https://github.com/user-attachments/assets/bd4aa287-6364-47a1-a466-213d33549924

The after is like this. There is no need to mention that it behaves correctly, whether the developer enables the edge-to-edge feature or not.

https://github.com/user-attachments/assets/873cc2fd-042c-4ce1-9961-978a7747cc45

Thank you.

@ceyhun-o @georgechoustoulakis @MattiasBuelens @tvanlaerhoven

