### PR TITLE
Fix various issues with ads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 ## v1.7.1 (2024-08-20)
 
 * 🐛 Disable system gestures on the `SeekBar` component. ([#30](https://github.com/THEOplayer/android-ui/pull/30)) 
+* 🐛 Fixed ad clickthrough not working. ([#33](https://github.com/THEOplayer/android-ui/pull/33))
+* 🐛 Fixed UI not re-appearing after playing an ad. ([#33](https://github.com/THEOplayer/android-ui/pull/33))
 
 ## v1.7.0 (2024-08-12)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ ui-test-junit4 = "1.6.8" # ...not in BOM for some reason?
 androidx-junit = "1.2.1"
 androidx-espresso = "3.6.1"
 dokka = "1.9.20"
-theoplayer = "7.8.0"
+theoplayer = "7.10.0"
 
 [libraries]
 androidx-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -217,6 +217,10 @@ fun UIController(
 
     PlayerContainer(modifier = modifier, player = player) {
         CompositionLocalProvider(LocalPlayer provides player) {
+            if (player.playingAd) {
+                // Remove player UI entirely while playing an ad, to make clickthrough work
+                return@CompositionLocalProvider
+            }
             AnimatedContent(
                 label = "ContentAnimation",
                 modifier = Modifier
@@ -359,8 +363,7 @@ private fun PlayerContainer(
                         ViewCompositionStrategy.DisposeOnLifecycleDestroyed(lifecycle)
                     )
                     setContent {
-                        if (player.playingAd.not())
-                            ui()
+                        ui()
                     }
                 }
                 // Host the THEOplayer view inside our AndroidView

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -1,19 +1,48 @@
 package com.theoplayer.android.ui
 
 import android.view.ViewGroup
-import androidx.compose.animation.*
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
-import androidx.compose.foundation.layout.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.*
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -22,7 +51,7 @@ import com.theoplayer.android.api.THEOplayerView
 import com.theoplayer.android.api.cast.chromecast.PlayerCastState
 import com.theoplayer.android.api.source.SourceDescription
 import com.theoplayer.android.ui.theme.THEOplayerTheme
-import kotlinx.coroutines.*
+import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
@@ -330,7 +359,8 @@ private fun PlayerContainer(
                         ViewCompositionStrategy.DisposeOnLifecycleDestroyed(lifecycle)
                     )
                     setContent {
-                        ui()
+                        if (player.playingAd.not())
+                            ui()
                     }
                 }
                 // Host the THEOplayer view inside our AndroidView


### PR DESCRIPTION
* The UI was correctly hidden while playing an ad, but it was still intercepting touches which prevented the clickthrough from working. Instead, we now completely remove the UI while in an ad.
* The UI was not re-appearing correctly after finishing an ad. This happened because we were listening for `adend`, and `player.ads.isPlaying` was still true when that event fires. Fix it by listening to `adbreakend` instead.

Supersedes #31. (Thanks @m-derakhshan for reporting and proposing the initial fix!)