### PR TITLE
Fix Chromecast setup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,4 +79,5 @@ dependencies {
     implementation(libs.theoplayer)
     implementation(libs.theoplayer.ads)
     implementation(libs.theoplayer.ads.ima)
+    implementation(libs.theoplayer.cast)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,8 @@ dependencies {
     implementation(libs.androidx.compose.ui.toolingPreview)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.iconsExtended)
+    implementation(libs.androidx.mediarouter)
+    implementation(libs.playServices.castFramework)
     testImplementation(libs.junit4)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <meta-data
+            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
+            android:value="com.theoplayer.android.ui.demo.CastOptionsProvider" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/theoplayer/android/ui/demo/CastOptionsProvider.kt
+++ b/app/src/main/java/com/theoplayer/android/ui/demo/CastOptionsProvider.kt
@@ -1,0 +1,30 @@
+package com.theoplayer.android.ui.demo
+
+import android.content.Context
+import com.google.android.gms.cast.CastMediaControlIntent
+import com.google.android.gms.cast.framework.CastOptions
+import com.google.android.gms.cast.framework.OptionsProvider
+import com.google.android.gms.cast.framework.SessionProvider
+import com.google.android.gms.cast.framework.media.CastMediaOptions
+import com.google.android.gms.cast.framework.media.NotificationOptions
+
+class CastOptionsProvider : OptionsProvider {
+    override fun getCastOptions(context: Context): CastOptions {
+        val notificationOptions = NotificationOptions.Builder()
+            .setTargetActivityClassName(MainActivity::class.java.name)
+            .build()
+
+        val castMediaOptions = CastMediaOptions.Builder()
+            .setNotificationOptions(notificationOptions)
+            .build()
+
+        return CastOptions.Builder()
+            .setReceiverApplicationId(CastMediaControlIntent.DEFAULT_MEDIA_RECEIVER_APPLICATION_ID)
+            .setCastMediaOptions(castMediaOptions)
+            .build()
+    }
+
+    override fun getAdditionalSessionProviders(context: Context): List<SessionProvider>? {
+        return null
+    }
+}

--- a/app/src/main/java/com/theoplayer/android/ui/demo/MainActivity.kt
+++ b/app/src/main/java/com/theoplayer/android/ui/demo/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import com.google.android.gms.cast.framework.CastContext
 import com.theoplayer.android.api.THEOplayerConfig
 import com.theoplayer.android.api.ads.ima.GoogleImaIntegrationFactory
 import com.theoplayer.android.api.cast.CastConfiguration
@@ -36,6 +37,9 @@ import com.theoplayer.android.ui.theme.THEOplayerTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Initialize Chromecast immediately, for automatic receiver discovery to work correctly.
+        CastContext.getSharedInstance(this)
 
         setContent {
             THEOplayerTheme(useDarkTheme = true) {

--- a/app/src/main/java/com/theoplayer/android/ui/demo/MainActivity.kt
+++ b/app/src/main/java/com/theoplayer/android/ui/demo/MainActivity.kt
@@ -24,6 +24,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.theoplayer.android.api.THEOplayerConfig
 import com.theoplayer.android.api.ads.ima.GoogleImaIntegrationFactory
+import com.theoplayer.android.api.cast.CastConfiguration
+import com.theoplayer.android.api.cast.CastIntegrationFactory
+import com.theoplayer.android.api.cast.CastStrategy
 import com.theoplayer.android.ui.DefaultUI
 import com.theoplayer.android.ui.demo.nitflex.NitflexUI
 import com.theoplayer.android.ui.demo.nitflex.theme.NitflexTheme
@@ -51,7 +54,17 @@ fun MainContent() {
     val player = rememberPlayer()
     LaunchedEffect(player) {
         player.theoplayerView?.let { theoplayerView ->
-            theoplayerView.player.addIntegration(GoogleImaIntegrationFactory.createGoogleImaIntegration(theoplayerView))
+            // Add ads integration through Google IMA
+            theoplayerView.player.addIntegration(
+                GoogleImaIntegrationFactory.createGoogleImaIntegration(theoplayerView)
+            )
+            // Add Chromecast integration
+            val castConfiguration = CastConfiguration.Builder().apply {
+                castStrategy(CastStrategy.AUTO)
+            }.build()
+            theoplayerView.player.addIntegration(
+                CastIntegrationFactory.createCastIntegration(theoplayerView, castConfiguration)
+            )
         }
     }
     LaunchedEffect(player, stream) {

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.THEOplayerAndroidUI" parent="android:Theme.Material.Light.NoActionBar">
+    <!-- This MUST be a Theme.AppCompat theme for the Chromecast MediaRouteChooserDialog to work! -->
+    <style name="Theme.THEOplayerAndroidUI" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:statusBarColor">@color/purple_700</item>
     </style>
 </resources>

--- a/docs/guides/chromecast.md
+++ b/docs/guides/chromecast.md
@@ -1,0 +1,105 @@
+---
+sidebar_position: 2
+---
+
+# Setting up Chromecast
+
+The Open Video UI for Android has integrated support for Chromecast.
+
+- When using the `DefaultUI`, the Chromecast button is automatically added in the top right corner
+  of the player.
+- When creating a custom UI using a `UIController`, you can add a `ChromecastButton` component
+  anywhere you like.
+  You should also add a `ChromecastDisplay` to show a "Playing on Chromecast" message while casting.
+
+However, you need to perform some additional setup to get it fully working.
+
+## Install the THEOplayer Cast integration
+
+The Chromecast support requires the THEOplayer Cast integration to be included in your app.
+We'll also need to interact with the Cast Application Framework directly, so we'll include that too:
+
+```groovy title="build.gradle"
+dependencies {
+    implementation "com.theoplayer.theoplayer-sdk-android:core:7.+"
+    // highlight-next-line
+    implementation "com.theoplayer.theoplayer-sdk-android:integration-cast:7.+"
+    // highlight-next-line
+    implementation "com.google.android.gms:play-services-cast-framework:21.5.0"
+    implementation "com.theoplayer.android-ui:android-ui:1.+"
+}
+```
+
+Create the player manually using `rememberPlayer()`, and then create and add the cast integration:
+
+```kotlin title="MainActivity.kt"
+import com.theoplayer.android.api.cast.CastConfiguration
+import com.theoplayer.android.api.cast.CastIntegrationFactory
+import com.theoplayer.android.api.cast.CastStrategy
+
+setContent {
+    val player = rememberPlayer()
+    LaunchedEffect(player) {
+        player.theoplayerView?.let { theoplayerView ->
+            // Add Chromecast integration
+            val castConfiguration = CastConfiguration.Builder().apply {
+                castStrategy(CastStrategy.AUTO)
+            }.build()
+            theoplayerView.player.addIntegration(
+                CastIntegrationFactory.createCastIntegration(theoplayerView, castConfiguration)
+            )
+        }
+    }
+
+    DefaultUI(
+        player = player
+    )
+}
+```
+
+## Initialize the `CastContext` during activity creation
+
+The Cast Application Framework handles automatic discovery of Chromecast receivers.
+However, this only works correctly if the `CastContext` is initialized immediately when
+your app's activity is constructed.
+
+Therefore, make sure to call `CastContext.getSharedInstance(this)` inside `Activity.onCreate()`:
+
+```kotlin title="MainActivity.kt"
+import com.google.android.gms.cast.framework.CastContext
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Initialize Chromecast immediately, for automatic receiver discovery to work correctly.
+        CastContext.getSharedInstance(this)
+
+        setContent {
+            // ...
+        }
+    }
+}
+```
+
+## Use an `AppCompat` theme
+
+The Cast Application Framework creates dialogs such as
+[MediaRouteChooserDialog](https://developer.android.com/reference/androidx/mediarouter/app/MediaRouteChooserDialog)
+and [MediaRouteControllerDialog](https://developer.android.com/reference/androidx/mediarouter/app/MediaRouteControllerDialog)
+to start and control a cast session. However, because these dialogs inherit
+from [AppCompatDialog](https://developer.android.com/reference/androidx/appcompat/app/AppCompatDialog),
+you need to use theme based on `Theme.AppCompat` in your app:
+
+```xml title="src/main/res/values/themes.xml"
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- don't do this:
+    <style name="Theme.MyAppTheme" parent="android:Theme.Material.Light.NoActionBar">
+         instead, do this:
+    -->
+    <style name="Theme.MyAppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <!-- your app's theme colors go here -->
+    </style>
+</resources>
+```

--- a/docs/guides/custom-ui.md
+++ b/docs/guides/custom-ui.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # Making a custom UI
 
 Although the default UI was designed to support a variety of usage scenarios, you may still run into a case that it doesn't handle very well. Perhaps you want to move some buttons around, or add like and dislike buttons to the control bar, or perhaps integrate a text chat component inside your player. In these situations, you may want to build a custom player UI to create a truly unique experience for your viewers.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
 theoplayer = { group = "com.theoplayer.theoplayer-sdk-android", name = "core", version.ref = "theoplayer" }
 theoplayer-ads = { group = "com.theoplayer.theoplayer-sdk-android", name = "integration-ads", version.ref = "theoplayer" }
 theoplayer-ads-ima = { group = "com.theoplayer.theoplayer-sdk-android", name = "integration-ads-ima", version.ref = "theoplayer" }
+theoplayer-cast = { group = "com.theoplayer.theoplayer-sdk-android", name = "integration-cast", version.ref = "theoplayer" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "gradle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,9 +7,11 @@ activity-compose = "1.9.1"
 appcompat = "1.7.0"
 compose-bom = "2024.06.00"
 junit4 = "4.13.2"
+playServices-castFramework = "21.5.0"
 ui-test-junit4 = "1.6.8" # ...not in BOM for some reason?
 androidx-junit = "1.2.1"
 androidx-espresso = "3.6.1"
+androidx-mediarouter = "1.7.0"
 dokka = "1.9.20"
 theoplayer = "7.10.0"
 
@@ -29,6 +31,8 @@ androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-compose-ui-toolingPreview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-junit" }
 androidx-espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-espresso" }
+androidx-mediarouter = { group = "androidx.mediarouter", name = "mediarouter", version.ref = "androidx-mediarouter" }
+playServices-castFramework = { group = "com.google.android.gms", name = "play-services-cast-framework", version.ref = "playServices-castFramework" }
 gradle-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "gradle" }
 dokka-base = { group = "org.jetbrains.dokka", name = "dokka-base", version.ref = "dokka" }
 dokka-plugin = { group = "org.jetbrains.dokka", name = "android-documentation-plugin", version.ref = "dokka" }

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -167,14 +167,14 @@ fun UIController(
         derivedStateOf {
             if (!isReady) {
                 false
-            } else if (!player.firstPlay) {
+            } else if (!player.firstPlay || player.castState == PlayerCastState.CONNECTED) {
                 true
             } else if (player.playingAd) {
                 false
             } else if (forceControlsHidden) {
                 false
             } else {
-                isRecentlyTapped || isPressed || player.paused || player.castState == PlayerCastState.CONNECTED
+                isRecentlyTapped || isPressed || player.paused
             }
         }
     }


### PR DESCRIPTION
The `ChromecastButton` wasn't working correctly:
* It didn't show up automatically, even when there are Chromecast receivers available on the Wi-Fi network.
* When starting to cast, the app crashed with the following error:
  ```
  java.lang.IllegalArgumentException: background can not be translucent: #0
      at androidx.core.graphics.ColorUtils.calculateContrast(ColorUtils.java:176)
      at androidx.mediarouter.app.MediaRouterThemeHelper.getControllerColor(MediaRouterThemeHelper.java:179)
      at androidx.mediarouter.app.MediaRouterThemeHelper.getRouterThemeId(MediaRouterThemeHelper.java:314)
      at androidx.mediarouter.app.MediaRouterThemeHelper.createThemedDialogStyle(MediaRouterThemeHelper.java:158)
      at androidx.mediarouter.app.MediaRouteChooserDialog.<init>(MediaRouteChooserDialog.java:142)
  ```

This PR fixes these issues, and makes Chromecast work out-of-the-box in our demo app. I also added a new guide explaining how to do this in your own app.

Thanks @ceyhun-o for reporting!