### PR TITLE
Add support for THEOplayer 8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 🚀 Added support for THEOplayer 8.0.
+
 ## v1.7.4 (2024-09-02)
 
 * 🐛 Fixed a crash when playing a live stream on Chromecast.

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -87,7 +87,7 @@ dependencies {
 
     implementation(libs.theoplayer) {
         version {
-            strictly("[5.0, 8.0)")
+            strictly("[5.0, 9.0)")
         }
     }
 


### PR DESCRIPTION
Open Video UI is not affected by any of the breaking changes, so this is just a simple version bump.