### PR TITLE
Update Jetpack Compose to 2024.09.00

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.10" />
+    <option name="version" value="1.9.25" />
   </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 💥 Updated to Jetpack Compose version 1.7.0 ([BOM](https://developer.android.com/jetpack/compose/bom) 2024.09.00).
+* 💥 Changed `colors` parameter in `IconButton` and `LiveButton` to be an `IconButtonColors`.
+
 ## v1.8.0 (2024-09-06)
 
 * 🚀 Added support for THEOplayer 8.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * 💥 Updated to Jetpack Compose version 1.7.0 ([BOM](https://developer.android.com/jetpack/compose/bom) 2024.09.00).
 * 💥 Changed `colors` parameter in `IconButton` and `LiveButton` to be an `IconButtonColors`.
+* 🚀 Added support for Android Lollipop (API 21), to align with the THEOplayer Android SDK.
 
 ## v1.8.0 (2024-09-06)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,7 +45,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.15"
     }
     packaging {
         resources {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
 
     implementation(libs.androidx.ktx)
-    implementation(libs.androidx.lifecycle.runtime)
+    implementation(libs.androidx.lifecycle.compose)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.compose.ui.ui)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId = "com.theoplayer.android.ui.demo"
-        minSdk = 24
+        minSdk = 21
         targetSdk = 33
         versionCode = 1
         versionName = "1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-gradle = "8.3.2"
+gradle = "8.5.2"
 kotlin-gradle-plugin = "1.9.25"
 ktx = "1.13.1"
 lifecycle-compose = "2.8.5"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
 gradle = "8.3.2"
-kotlin-gradle-plugin = "1.8.10"
+kotlin-gradle-plugin = "1.9.25"
 ktx = "1.13.1"
-lifecycle-runtime = "2.8.4"
-activity-compose = "1.9.1"
+lifecycle-runtime = "2.8.5"
+activity-compose = "1.9.2"
 appcompat = "1.7.0"
-compose-bom = "2024.06.00"
+compose-bom = "2024.09.00"
 junit4 = "4.13.2"
 playServices-castFramework = "21.5.0"
-ui-test-junit4 = "1.6.8" # ...not in BOM for some reason?
+ui-test-junit4 = "1.7.0" # ...not in BOM for some reason?
 androidx-junit = "1.2.1"
 androidx-espresso = "3.6.1"
 androidx-mediarouter = "1.7.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 gradle = "8.3.2"
 kotlin-gradle-plugin = "1.9.25"
 ktx = "1.13.1"
-lifecycle-runtime = "2.8.5"
+lifecycle-compose = "2.8.5"
 activity-compose = "1.9.2"
 appcompat = "1.7.0"
 compose-bom = "2024.09.00"
@@ -17,7 +17,7 @@ theoplayer = "7.11.0"
 
 [libraries]
 androidx-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
-androidx-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle-runtime" }
+androidx-lifecycle-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle-compose" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Nov 20 16:01:06 CET 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -23,7 +23,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 21
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -51,7 +51,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.15"
     }
     packaging {
         resources {

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
 
     implementation(libs.androidx.ktx)
-    implementation(libs.androidx.lifecycle.runtime)
+    implementation(libs.androidx.lifecycle.compose)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.compose.ui.ui)

--- a/ui/src/main/java/com/theoplayer/android/ui/ErrorDisplay.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/ErrorDisplay.kt
@@ -25,9 +25,7 @@ import androidx.compose.ui.unit.dp
 fun ErrorDisplay(
     modifier: Modifier = Modifier,
 ) {
-    val error = Player.current?.error
-
-    error?.let { it ->
+    Player.current?.error?.let { error ->
         Row(
             modifier = modifier,
             horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -50,7 +48,7 @@ fun ErrorDisplay(
                     )
                 }
                 Text(
-                    text = "${it.message}"
+                    text = "${error.message}"
                 )
             }
         }

--- a/ui/src/main/java/com/theoplayer/android/ui/IconButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/IconButton.kt
@@ -1,19 +1,29 @@
 package com.theoplayer.android.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ButtonColors
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonColors
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalContentColor
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 
 /**
@@ -40,57 +50,46 @@ fun IconButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    colors: ButtonColors = IconButtonDefaults.iconButtonColors(),
+    colors: IconButtonColors = IconButtonDefaults.iconButtonColors(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable () -> Unit
 ) {
-    TextButton(
+    Box(
         modifier = modifier
+            .minimumInteractiveComponentSize()
             .defaultMinSize(
                 minWidth = IconButtonSize,
                 minHeight = IconButtonSize
+            )
+            .padding(contentPadding)
+            .clip(CircleShape)
+            .background(color = colors.containerColor(enabled))
+            .clickable(
+                onClick = onClick,
+                enabled = enabled,
+                role = Role.Button,
+                interactionSource = interactionSource,
+                indication = ripple(bounded = false)
             ),
-        shape = androidx.compose.material3.IconButtonDefaults.filledShape,
-        enabled = enabled,
-        colors = colors,
-        contentPadding = contentPadding,
-        interactionSource = interactionSource,
-        onClick = onClick,
-        content = { content() }
-    )
-}
-
-private const val DisabledIconOpacity = 0.38f
-private val IconButtonSize = 40.dp
-
-/**
- * Contains the default values used by icon buttons.
- */
-object IconButtonDefaults {
-    /**
-     * Creates a [ButtonColors] that represents the default colors used in a [IconButton].
-     *
-     * Equivalent to [androidx.compose.material3.IconButtonDefaults.iconButtonColors],
-     * but as [ButtonColors] instead of [androidx.compose.material3.IconButtonColors].
-     *
-     * @param containerColor the container color of this icon button when enabled.
-     * @param contentColor the content color of this icon button when enabled.
-     * @param disabledContainerColor the container color of this icon button when not enabled.
-     * @param disabledContentColor the content color of this icon button when not enabled.
-     */
-    @Composable
-    fun iconButtonColors(
-        containerColor: Color = Color.Transparent,
-        contentColor: Color = LocalContentColor.current,
-        disabledContainerColor: Color = Color.Transparent,
-        disabledContentColor: Color = contentColor.copy(alpha = DisabledIconOpacity)
-    ): ButtonColors {
-        return ButtonDefaults.textButtonColors(
-            containerColor = containerColor,
-            contentColor = contentColor,
-            disabledContainerColor = disabledContainerColor,
-            disabledContentColor = disabledContentColor
-        )
+        contentAlignment = Alignment.Center
+    ) {
+        val contentColor = colors.contentColor(enabled)
+        CompositionLocalProvider(LocalContentColor provides contentColor, content = content)
     }
 }
+
+private val IconButtonSize = 40.dp
+
+private fun IconButtonColors.containerColor(enabled: Boolean): Color =
+    if (enabled) containerColor else disabledContainerColor
+
+private fun IconButtonColors.contentColor(enabled: Boolean): Color =
+    if (enabled) contentColor else disabledContentColor
+
+internal fun IconButtonColors.toButtonColors() = ButtonColors(
+    containerColor = containerColor,
+    contentColor = contentColor,
+    disabledContainerColor = disabledContainerColor,
+    disabledContentColor = disabledContentColor
+)

--- a/ui/src/main/java/com/theoplayer/android/ui/LiveButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/LiveButton.kt
@@ -8,6 +8,8 @@ import androidx.compose.material.icons.rounded.Circle
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonColors
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -35,7 +37,7 @@ import com.theoplayer.android.ui.theme.THEOplayerTheme
 fun LiveButton(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = ButtonDefaults.TextButtonContentPadding,
-    colors: ButtonColors = IconButtonDefaults.iconButtonColors(),
+    colors: IconButtonColors = IconButtonDefaults.iconButtonColors(),
     liveThreshold: Double = 10.0,
     live: @Composable RowScope.() -> Unit = {
         Icon(
@@ -63,7 +65,7 @@ fun LiveButton(
         TextButton(
             modifier = modifier,
             contentPadding = contentPadding,
-            colors = colors,
+            colors = colors.toButtonColors(),
             onClick = {
                 player.player?.let {
                     it.currentTime = Double.POSITIVE_INFINITY

--- a/ui/src/main/java/com/theoplayer/android/ui/SeekBar.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SeekBar.kt
@@ -1,15 +1,34 @@
 package com.theoplayer.android.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.DragInteraction
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.systemGestureExclusion
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderColors
 import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.SliderDefaults.colors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import com.theoplayer.android.api.cast.chromecast.PlayerCastState
 
 /**
@@ -21,6 +40,7 @@ import com.theoplayer.android.api.cast.chromecast.PlayerCastState
  * @param colors [SliderColors] that will be used to resolve the colors used for this seek bar in
  * different states. See [SliderDefaults.colors].
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SeekBar(
     modifier: Modifier = Modifier,
@@ -46,12 +66,34 @@ fun SeekBar(
     var seekTime by remember { mutableStateOf<Float?>(null) }
     var wasPlayingBeforeSeek by remember { mutableStateOf(false) }
 
+    val interactionSource = remember { MutableInteractionSource() }
+
     Slider(
         modifier = modifier.systemGestureExclusion(),
         colors = colors,
         value = seekTime ?: currentTime,
         valueRange = valueRange,
         enabled = enabled,
+        interactionSource = interactionSource,
+        thumb = {
+            SeekBarThumb(
+                interactionSource = interactionSource,
+                colors = colors,
+                enabled = enabled
+            )
+        },
+        track = { sliderState ->
+            SliderDefaults.Track(
+                modifier = Modifier.height(4.dp),
+                colors = colors,
+                enabled = enabled,
+                sliderState = sliderState,
+                // Don't draw the stop indicator at the end of the track
+                drawStopIndicator = {},
+                // Remove the gap in the track around the thumb
+                thumbTrackGapSize = 0.dp
+            )
+        },
         onValueChange = remember {
             { time ->
                 seekTime = time
@@ -78,3 +120,59 @@ fun SeekBar(
         }
     )
 }
+
+private val ThumbSize = DpSize(20.dp, 20.dp)
+private val ThumbDefaultElevation = 1.dp
+private val ThumbPressedElevation = 6.dp
+private val StateLayerSize = 40.0.dp
+
+// Slider.Thumb look-and-feel from Compose Material3 version 1.2.1
+// https://github.com/androidx/androidx/blob/d4655d87a9f8dbced1c3c768a595cbfcea505c07/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/Slider.kt#L980
+@Composable
+private fun SeekBarThumb(
+    interactionSource: MutableInteractionSource,
+    modifier: Modifier = Modifier,
+    colors: SliderColors = colors(),
+    enabled: Boolean = true,
+    thumbSize: DpSize = ThumbSize
+) {
+    val interactions = remember { mutableStateListOf<Interaction>() }
+    LaunchedEffect(interactionSource) {
+        interactionSource.interactions.collect { interaction ->
+            when (interaction) {
+                is PressInteraction.Press -> interactions.add(interaction)
+                is PressInteraction.Release -> interactions.remove(interaction.press)
+                is PressInteraction.Cancel -> interactions.remove(interaction.press)
+                is DragInteraction.Start -> interactions.add(interaction)
+                is DragInteraction.Stop -> interactions.remove(interaction.start)
+                is DragInteraction.Cancel -> interactions.remove(interaction.start)
+            }
+        }
+    }
+
+    val elevation = if (interactions.isNotEmpty()) {
+        ThumbPressedElevation
+    } else {
+        ThumbDefaultElevation
+    }
+    val shape = CircleShape
+
+    @Suppress("DEPRECATION_ERROR")
+    (Spacer(
+        modifier
+            .size(thumbSize)
+            .indication(
+                interactionSource = interactionSource,
+                indication = androidx.compose.material.ripple.rememberRipple(
+                    bounded = false,
+                    radius = StateLayerSize / 2
+                )
+            )
+            .hoverable(interactionSource = interactionSource)
+            .shadow(if (enabled) elevation else 0.dp, shape, clip = false)
+            .background(colors.thumbColor(enabled), shape)
+    ))
+}
+
+private fun SliderColors.thumbColor(enabled: Boolean): Color =
+    if (enabled) thumbColor else disabledThumbColor

--- a/ui/src/main/java/com/theoplayer/android/ui/SeekBar.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SeekBar.kt
@@ -96,21 +96,21 @@ fun SeekBar(
             )
         },
         onValueChange = { time ->
-                seekTime = time
-                player?.player?.let {
-                    if (!it.isPaused) {
-                        wasPlayingBeforeSeek = true
-                        it.pause()
-                    }
-                    it.currentTime = time.toDouble()
+            seekTime = time
+            player?.player?.let {
+                if (!it.isPaused) {
+                    wasPlayingBeforeSeek = true
+                    it.pause()
                 }
+                it.currentTime = time.toDouble()
+            }
         },
         onValueChangeFinished = {
-                seekTime = null
-                if (wasPlayingBeforeSeek) {
-                    player?.player?.play()
-                    wasPlayingBeforeSeek = false
-                }
+            seekTime = null
+            if (wasPlayingBeforeSeek) {
+                player?.player?.play()
+                wasPlayingBeforeSeek = false
+            }
         }
     )
 }

--- a/ui/src/main/java/com/theoplayer/android/ui/SeekBar.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SeekBar.kt
@@ -95,8 +95,7 @@ fun SeekBar(
                 thumbTrackGapSize = 0.dp
             )
         },
-        onValueChange = remember {
-            { time ->
+        onValueChange = { time ->
                 seekTime = time
                 player?.player?.let {
                     if (!it.isPaused) {
@@ -105,19 +104,13 @@ fun SeekBar(
                     }
                     it.currentTime = time.toDouble()
                 }
-            }
         },
-        // This needs to always be the *same* callback,
-        // otherwise Slider will reset its internal SliderState while dragging.
-        // https://github.com/androidx/androidx/blob/4d69c45e6361a2e5af77edc9f7f92af3d0db3877/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/Slider.kt#L270-L282
-        onValueChangeFinished = remember {
-            {
+        onValueChangeFinished = {
                 seekTime = null
                 if (wasPlayingBeforeSeek) {
                     player?.player?.play()
                     wasPlayingBeforeSeek = false
                 }
-            }
         }
     )
 }

--- a/ui/src/main/java/com/theoplayer/android/ui/SeekBar.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SeekBar.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderColors
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.SliderDefaults.colors
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -157,13 +158,12 @@ private fun SeekBarThumb(
     }
     val shape = CircleShape
 
-    @Suppress("DEPRECATION_ERROR")
-    (Spacer(
+    Spacer(
         modifier
             .size(thumbSize)
             .indication(
                 interactionSource = interactionSource,
-                indication = androidx.compose.material.ripple.rememberRipple(
+                indication = ripple(
                     bounded = false,
                     radius = StateLayerSize / 2
                 )
@@ -171,7 +171,7 @@ private fun SeekBarThumb(
             .hoverable(interactionSource = interactionSource)
             .shadow(if (enabled) elevation else 0.dp, shape, clip = false)
             .background(colors.thumbColor(enabled), shape)
-    ))
+    )
 }
 
 private fun SliderColors.thumbColor(enabled: Boolean): Color =

--- a/ui/src/main/java/com/theoplayer/android/ui/SeekBar.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SeekBar.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderColors
 import androidx.compose.material3.SliderDefaults
-import androidx.compose.material3.SliderDefaults.colors
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -126,7 +125,7 @@ private val StateLayerSize = 40.0.dp
 private fun SeekBarThumb(
     interactionSource: MutableInteractionSource,
     modifier: Modifier = Modifier,
-    colors: SliderColors = colors(),
+    colors: SliderColors = SliderDefaults.colors(),
     enabled: Boolean = true,
     thumbSize: DpSize = ThumbSize
 ) {

--- a/ui/src/main/java/com/theoplayer/android/ui/SeekButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SeekButton.kt
@@ -57,8 +57,8 @@ fun SeekButton(
             )
             Text(
                 modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .offset(y = iconSize * 0.4f),
+                    .align(Alignment.Center)
+                    .offset(y = iconSize * 0.1f),
                 text = "${seekOffset.absoluteValue}",
                 fontSize = 6.sp * (iconSize / 24.dp)
             )

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -41,11 +41,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.theoplayer.android.api.THEOplayerConfig
 import com.theoplayer.android.api.THEOplayerView
 import com.theoplayer.android.api.cast.chromecast.PlayerCastState


### PR DESCRIPTION
Jetpack Compose 1.7.0 was released, which included a complete rework of the `Slider` component look-and-feel. It follows [the latest Material Design guidelines](https://m3.material.io/components/sliders/overview), which gives it a thin vertical thumb rather than a round thumb:
![image](https://github.com/user-attachments/assets/4058eca9-4717-4ae1-825c-ee9c911356ea)
This doesn't look very nice when used for our `SeekBar`, so I reverted ours to look like the old design again.

I also aligned our `IconButton` with Material3's `IconButton`, and fixed the type of the `colors` parameter.