### PR TITLE
Improve time display for live streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 🐛 Fix `DurationDisplay` to show the time of the live point when playing a live or DVR stream.
+* 🐛 Fix `CurrentTimeDisplay` to show the time offset to the live point when playing a live or DVR stream with `showRemaining = true`.
+* 💅 Changed `DefaultUi` to hide the current time display when playing a live stream.
+* 💅 Changed `DefaultUi` to show the time offset to the live point when playing a DVR stream.
+
 ## v1.9.0 (2024-09-10)
 
 * 💥 Updated to Jetpack Compose version 1.7.0 ([BOM](https://developer.android.com/jetpack/compose/bom) 2024.09.00).

--- a/ui/src/main/java/com/theoplayer/android/ui/CurrentTimeDisplay.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/CurrentTimeDisplay.kt
@@ -21,7 +21,7 @@ fun CurrentTimeDisplay(
 ) {
     val player = Player.current
     val currentTime = player?.currentTime ?: 0.0
-    val duration = player?.duration ?: Double.NaN
+    val duration = player?.seekable?.lastEnd ?: player?.duration ?: Double.NaN
 
     val time = if (showRemaining) {
         -(duration - currentTime)

--- a/ui/src/main/java/com/theoplayer/android/ui/DefaultUI.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/DefaultUI.kt
@@ -112,7 +112,12 @@ fun DefaultUI(
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     MuteButton()
                     LiveButton()
-                    CurrentTimeDisplay(showDuration = true)
+                    if (player.streamType != StreamType.Live) {
+                        CurrentTimeDisplay(
+                            showRemaining = player.streamType == StreamType.Dvr,
+                            showDuration = player.streamType == StreamType.Vod
+                        )
+                    }
                     Spacer(modifier = Modifier.weight(1f))
                     FullscreenButton()
                 }

--- a/ui/src/main/java/com/theoplayer/android/ui/DurationDisplay.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/DurationDisplay.kt
@@ -14,7 +14,7 @@ fun DurationDisplay(
     modifier: Modifier = Modifier
 ) {
     val player = Player.current
-    val duration = player?.duration ?: Double.NaN
+    val duration = player?.seekable?.lastEnd ?: player?.duration ?: Double.NaN
 
     Text(modifier = modifier, text = formatTime(duration))
 }


### PR DESCRIPTION
Previously, when playing a live stream, the default UI would show something like `12:34 / --:--`. This isn't very useful:
* When playing a DVR stream, we're interested in how far behind the live point we're playing.
* When playing a live (non-DVR) stream, we shouldn't show the current time at all.

This PR fixes that.