### PR TITLE
Hide `LanguageMenuButton` automatically when empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * 🐛 Fix `CurrentTimeDisplay` to show the time offset to the live point when playing a live or DVR stream with `showRemaining = true`.
 * 💅 Changed `DefaultUi` to hide the current time display when playing a live stream.
 * 💅 Changed `DefaultUi` to show the time offset to the live point when playing a DVR stream.
+* 💅 Changed `LanguageMenuButton` to automatically hide itself when there are no alternative audio or subtitle tracks to select.
 
 ## v1.9.0 (2024-09-10)
 

--- a/ui/src/main/java/com/theoplayer/android/ui/LanguageMenu.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/LanguageMenu.kt
@@ -48,11 +48,11 @@ fun MenuScope.LanguageMenu() {
     }
 }
 
-private fun showAudioTracks(player: Player?): Boolean {
+internal fun showAudioTracks(player: Player?): Boolean {
     return player != null && player.audioTracks.size >= 2
 }
 
-private fun showSubtitleTracks(player: Player?): Boolean {
+internal fun showSubtitleTracks(player: Player?): Boolean {
     return player != null && player.subtitleTracks.isNotEmpty()
 }
 

--- a/ui/src/main/java/com/theoplayer/android/ui/LanguageMenuButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/LanguageMenuButton.kt
@@ -25,10 +25,20 @@ fun MenuScope.LanguageMenuButton(
         )
     }
 ) {
+    val player = Player.current
+    if (!showLanguageMenuButton(player)) {
+        // Hide when no alternative audio or subtitle tracks are available
+        return
+    }
+
     IconButton(
         modifier = modifier,
         contentPadding = contentPadding,
         onClick = { openMenu { LanguageMenu() } }) {
         content()
     }
+}
+
+internal fun showLanguageMenuButton(player: Player?): Boolean {
+    return showAudioTracks(player) || showSubtitleTracks(player)
 }


### PR DESCRIPTION
There's no point showing the button if the menu is empty.