### PR TITLE
Remove the unnecessary integration-ads module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,7 +79,6 @@ dependencies {
     "mavenImplementation"("com.theoplayer.android-ui:android-ui:1.+")
 
     implementation(libs.theoplayer)
-    implementation(libs.theoplayer.ads)
     implementation(libs.theoplayer.ads.ima)
     implementation(libs.theoplayer.cast)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,6 @@ dokka-plugin = { group = "org.jetbrains.dokka", name = "android-documentation-pl
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin-gradle-plugin" }
 junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
 theoplayer = { group = "com.theoplayer.theoplayer-sdk-android", name = "core", version.ref = "theoplayer" }
-theoplayer-ads = { group = "com.theoplayer.theoplayer-sdk-android", name = "integration-ads", version.ref = "theoplayer" }
 theoplayer-ads-ima = { group = "com.theoplayer.theoplayer-sdk-android", name = "integration-ads-ima", version.ref = "theoplayer" }
 theoplayer-cast = { group = "com.theoplayer.theoplayer-sdk-android", name = "integration-cast", version.ref = "theoplayer" }
 


### PR DESCRIPTION
This PR removes the `com.theoplayer.theoplayer-sdk-android:integration-ads` module from the sample application as it is no longer published as of THEOplayer 8.2.0.

This module was never needed to be imported explicitly since the IMA module was already importing it as a dependency. Since THEOplayer 8.2.0, all the logic inside the `integration-ads` module is part of the `integration-ads-ima` module.