### PR TITLE
Fix `Player.cast` not available before first source change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 🐛 Fix `Player.cast` not available before first source change.
+
 ## v1.9.1 (2024-10-01)
 
 * 🐛 Fix `DurationDisplay` to show the time of the live point when playing a live or DVR stream.


### PR DESCRIPTION
In #34, we added some logic to handle the case where the Chromecast integration is attached *after* we construct a `Player` instance. However, this only checks if the integration is attached when the player's source changed. If you tried to use `player.cast` *before* the first source is set on the player, it would always return `null`.

Fix it by trying to update `player.cast` on every access. In the future, we should have the THEOplayer Android SDK handle this better, for example `theoplayerView.cast` could return dummy values (instead of `null`) if the Chromecast integration is not attached.

Fixes #47