### PR TITLE
Fix seeking in livestreams with large seekable start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* Fix `SeekBar` not working for livestreams with a large `player.seekable.start(0)`,
+  such as MPEG-DASH streams that use Unix timestamps for their MPD timeline. ([#52](https://github.com/THEOplayer/android-ui/pull/52))
+
 ## v1.9.2 (2024-10-15)
 
 * 🐛 Fix `Player.cast` not available before first source change.

--- a/app/src/main/java/com/theoplayer/android/ui/demo/Streams.kt
+++ b/app/src/main/java/com/theoplayer/android/ui/demo/Streams.kt
@@ -27,6 +27,13 @@ val streams by lazy {
                     .timeOffset("start")
                     .build()
             ).build()
+        ),
+        Stream(
+            title = "DASH-IF Livesim",
+            source = SourceDescription.Builder(
+                TypedSource.Builder("https://livesim.dashif.org/livesim/testpic_2s/Manifest.mpd")
+                    .build()
+            ).build()
         )
     )
 }


### PR DESCRIPTION
Some MPEG-DASH livestreams use Unix timestamps as their MPD time. This means `player.currentTime` and `player.seekable` always return very large values (e.g. `1733337365`), but the *difference* between `seekable.start(0)` and `seekable.end(0)` can be very small (e.g. `60` for streams with a DVR window of 1 minute).

This becomes a problem when our `SeekBar` converts these values to a `Float` when passing them to the inner `Slider` composable. This conversion loses precision in the LSBs, which in the worst case scenario can make `valueRange.start` become equal to `valueRange.endInclusive`. In that case, seeking becomes impossible.

This PR fixes this problem by subtracting `seekable.start` for all value passed to the `Slider`, and adding it back when receiving values from the `Slider`. This makes it once again possible to seek in these live streams.