### PR TITLE
Add localization support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 🚀 Added localization support.
+  * See `res/values/strings.xml` for the full list of translatable strings, which you can override in your app's `strings.xml`.
+  * For more information, see [Localize your app on Android Developers](https://developer.android.com/guide/topics/resources/localization).
+
 ## v1.10.0 (2025-04-02)
 
 * 🚀 Added support for THEOplayer 9.0. ([#61](https://github.com/THEOplayer/android-ui/pulls/61))

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-</resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:locale="nl">
     <string name="app_name">THEOplayer Open Video UI voor Android Demo</string>
     <string name="theoplayer_ui_btn_play">Afspelen</string>
     <string name="theoplayer_ui_btn_pause">Pauzeren</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -12,8 +12,14 @@
     <string name="theoplayer_ui_btn_back">Terug</string>
     <string name="theoplayer_ui_btn_mute">Dempen</string>
     <string name="theoplayer_ui_btn_unmute">Dempen opheffen</string>
-    <string name="theoplayer_ui_btn_seek_forward">Spring vooruit met %1$s seconden</string>
-    <string name="theoplayer_ui_btn_seek_backward">Spring terug met %1$s seconden</string>
+    <plurals name="theoplayer_ui_btn_seek_forward">
+        <item quantity="one">Spring %1$s seconde vooruit</item>
+        <item quantity="other">Spring %1$s seconden vooruit</item>
+    </plurals>
+    <plurals name="theoplayer_ui_btn_seek_backward">
+        <item quantity="one">Spring %1$s seconde achteruit</item>
+        <item quantity="other">Spring %1$s seconden achteruit</item>
+    </plurals>
     <string name="theoplayer_ui_btn_live">LIVE</string>
     <string name="theoplayer_ui_chromecast_playing_on_receiver">Speelt op %1$s</string>
     <string name="theoplayer_ui_chromecast_playing_on_receiver_expanded_first_line">Speelt op</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -13,12 +13,12 @@
     <string name="theoplayer_ui_btn_mute">Dempen</string>
     <string name="theoplayer_ui_btn_unmute">Dempen opheffen</string>
     <plurals name="theoplayer_ui_btn_seek_forward">
-        <item quantity="one">Spring %1$s seconde vooruit</item>
-        <item quantity="other">Spring %1$s seconden vooruit</item>
+        <item quantity="one">Spring %1$d seconde vooruit</item>
+        <item quantity="other">Spring %1$d seconden vooruit</item>
     </plurals>
     <plurals name="theoplayer_ui_btn_seek_backward">
-        <item quantity="one">Spring %1$s seconde achteruit</item>
-        <item quantity="other">Spring %1$s seconden achteruit</item>
+        <item quantity="one">Spring %1$d seconde achteruit</item>
+        <item quantity="other">Spring %1$d seconden achteruit</item>
     </plurals>
     <string name="theoplayer_ui_btn_live">LIVE</string>
     <string name="theoplayer_ui_chromecast_playing_on_receiver">Speelt op %1$s</string>
@@ -36,7 +36,7 @@
     <string name="theoplayer_ui_subtitles_off">Uit</string>
     <string name="theoplayer_ui_playback_rate_normal">Normaal</string>
     <string name="theoplayer_ui_quality_automatic">Automatisch</string>
-    <string name="theoplayer_ui_quality_automatic_with_height">Automatisch (%1$sp)</string>
+    <string name="theoplayer_ui_quality_automatic_with_height">Automatisch (%1$dp)</string>
     <string name="theoplayer_ui_track_unknown">Onbekend</string>
     <string name="theoplayer_ui_error_title">Fout</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">THEOplayer Open Video UI voor Android Demo</string>
+    <string name="theoplayer_ui_btn_play">Afspelen</string>
+    <string name="theoplayer_ui_btn_pause">Pauzeren</string>
+    <string name="theoplayer_ui_btn_replay">Opnieuw spelen</string>
+    <string name="theoplayer_ui_btn_chromecast_start">Starten met casten</string>
+    <string name="theoplayer_ui_btn_chromecast_stop">Stop casting</string>
+    <string name="theoplayer_ui_btn_fullscreen_enter">Volledig scherm</string>
+    <string name="theoplayer_ui_btn_fullscreen_exit">Volledig scherm sluiten</string>
+    <string name="theoplayer_ui_btn_menu_close">Sluiten</string>
+    <string name="theoplayer_ui_btn_back">Terug</string>
+    <string name="theoplayer_ui_btn_mute">Dempen</string>
+    <string name="theoplayer_ui_btn_unmute">Dempen opheffen</string>
+    <string name="theoplayer_ui_btn_seek_forward">Spring vooruit met %1$s seconden</string>
+    <string name="theoplayer_ui_btn_seek_backward">Spring terug met %1$s seconden</string>
+    <string name="theoplayer_ui_btn_live">LIVE</string>
+    <string name="theoplayer_ui_chromecast_playing_on_receiver">Speelt op %1$s</string>
+    <string name="theoplayer_ui_chromecast_playing_on_receiver_expanded_first_line">Speelt op</string>
+    <string name="theoplayer_ui_chromecast_playing_on_unknown_receiver">Speelt op Chromecast</string>
+    <string name="theoplayer_ui_chromecast_playing_on_unknown_receiver_expanded_first_line">Speelt op</string>
+    <string name="theoplayer_ui_chromecast_playing_on_unknown_receiver_expanded_second_line">Chromecast</string>
+    <string name="theoplayer_ui_menu_language">Taal</string>
+    <string name="theoplayer_ui_menu_settings">Instellingen</string>
+    <string name="theoplayer_ui_menu_audio">Audio</string>
+    <string name="theoplayer_ui_menu_subtitles">Ondertitels</string>
+    <string name="theoplayer_ui_menu_playback_rate">Afspeelsnelheid</string>
+    <string name="theoplayer_ui_menu_quality">Kwaliteit</string>
+    <string name="theoplayer_ui_audio_none">Geen</string>
+    <string name="theoplayer_ui_subtitles_off">Uit</string>
+    <string name="theoplayer_ui_playback_rate_normal">Normaal</string>
+    <string name="theoplayer_ui_quality_automatic">Automatisch</string>
+    <string name="theoplayer_ui_quality_automatic_with_height">Automatisch (%1$sp)</string>
+    <string name="theoplayer_ui_track_unknown">Onbekend</string>
+    <string name="theoplayer_ui_error_title">Fout</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,53 @@
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="app_name">THEOplayer Open Video UI for Android Demo</string>
+
+    <!-- Copied from Open Video UI for Android -->
+    <string name="theoplayer_ui_btn_play">Play</string>
+    <string name="theoplayer_ui_btn_pause">Pause</string>
+    <string name="theoplayer_ui_btn_replay">Replay</string>
+    <string name="theoplayer_ui_btn_chromecast_start">Start casting</string>
+    <string name="theoplayer_ui_btn_chromecast_stop">Stop casting</string>
+    <string name="theoplayer_ui_btn_fullscreen_enter">Enter fullscreen</string>
+    <string name="theoplayer_ui_btn_fullscreen_exit">Exit fullscreen</string>
+    <string name="theoplayer_ui_btn_menu_close">Close</string>
+    <string name="theoplayer_ui_btn_back">Back</string>
+    <string name="theoplayer_ui_btn_mute">Mute</string>
+    <string name="theoplayer_ui_btn_unmute">Unmute</string>
+    <plurals name="theoplayer_ui_btn_seek_forward">
+        <item quantity="one">Seek forward by <xliff:g example="5" id="seek_offset">%1$d</xliff:g> second</item>
+        <item quantity="other">Seek forward by <xliff:g example="5" id="seek_offset">%1$d</xliff:g> seconds</item>
+    </plurals>
+    <plurals name="theoplayer_ui_btn_seek_backward">
+        <item quantity="one">Seek backward by <xliff:g example="5" id="seek_offset">%1$d</xliff:g> second</item>
+        <item quantity="other">Seek backward by <xliff:g example="5" id="seek_offset">%1$d</xliff:g> seconds</item>
+    </plurals>
+    <string name="theoplayer_ui_btn_live">LIVE</string>
+    <string name="theoplayer_ui_current_time" translatable="false"><xliff:g example="01:23" id="current_time">%1$s</xliff:g></string>
+    <string name="theoplayer_ui_current_time_remaining" translatable="false"><xliff:g example="-01:23" id="remaining_time">%1$s</xliff:g></string>
+    <string name="theoplayer_ui_current_time_with_duration" translatable="false"><xliff:g example="01:23" id="current_time">%1$s</xliff:g> / <xliff:g example="60:00" id="duration">%2$s</xliff:g></string>
+    <string name="theoplayer_ui_current_time_remaining_with_duration" translatable="false"><xliff:g example="-01:23" id="remaining_time">%1$s</xliff:g> / <xliff:g example="60:00" id="duration">%2$s</xliff:g></string>
+    <string name="theoplayer_ui_chromecast_playing_on_receiver">Playing on <xliff:g example="Living Room" id="receiver_name">%1$s</xliff:g></string>
+    <string name="theoplayer_ui_chromecast_playing_on_receiver_expanded_first_line">Playing on</string>
+    <string name="theoplayer_ui_chromecast_playing_on_receiver_expanded_second_line" translatable="false"><xliff:g example="Living Room" id="receiver_name">%1$s</xliff:g></string>
+    <string name="theoplayer_ui_chromecast_playing_on_unknown_receiver">Playing on Chromecast</string>
+    <string name="theoplayer_ui_chromecast_playing_on_unknown_receiver_expanded_first_line">Playing on</string>
+    <string name="theoplayer_ui_chromecast_playing_on_unknown_receiver_expanded_second_line">Chromecast</string>
+    <string name="theoplayer_ui_menu_language">Language</string>
+    <string name="theoplayer_ui_menu_settings">Settings</string>
+    <string name="theoplayer_ui_menu_audio">Audio</string>
+    <string name="theoplayer_ui_menu_subtitles">Subtitles</string>
+    <string name="theoplayer_ui_menu_playback_rate">Playback speed</string>
+    <string name="theoplayer_ui_menu_quality">Quality</string>
+    <string name="theoplayer_ui_audio_none">None</string>
+    <string name="theoplayer_ui_subtitles_off">Off</string>
+    <string name="theoplayer_ui_playback_rate_normal">Normal</string>
+    <string name="theoplayer_ui_playback_rate_format" translatable="false">#.##x</string>
+    <string name="theoplayer_ui_quality_automatic">Automatic</string>
+    <string name="theoplayer_ui_quality_with_height" translatable="false"><xliff:g example="720" id="quality_height">%1$d</xliff:g>p</string>
+    <string name="theoplayer_ui_quality_automatic_with_height">Automatic (<xliff:g example="720" id="quality_height">%1$d</xliff:g>p)</string>
+    <string name="theoplayer_ui_bandwidth_format_10mbps" translatable="false">#Mbps</string>
+    <string name="theoplayer_ui_bandwidth_format_1mbps" translatable="false">#.#Mbps</string>
+    <string name="theoplayer_ui_bandwidth_format_kbps" translatable="false">#kbps</string>
+    <string name="theoplayer_ui_track_unknown">Unknown</string>
+    <string name="theoplayer_ui_error_title">An error occurred</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+<resources xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" tools:locale="en">
     <string name="app_name">THEOplayer Open Video UI for Android Demo</string>
 
     <!-- Copied from Open Video UI for Android -->

--- a/docs/guides/localization.md
+++ b/docs/guides/localization.md
@@ -1,0 +1,81 @@
+---
+sidebar_position: 3
+---
+
+# Localization
+
+The Open Video UI for Android can be localized to different languages,
+enabling you to reach audiences from different regions of the world.
+
+Localization works
+by [providing alternative resources](https://developer.android.com/guide/topics/resources/providing-resources#AlternativeResources)
+in one or more languages. You can choose to [change the text of the default language](#change-default-language)
+to target a single audience, or [add alternative languages](#add-alternative-languages) to target many audiences.
+
+## Changing the default language {#change-default-language}
+
+By default, the Open Video UI ships with English texts only. If your app targets a non-English speaking audience,
+you can override these texts with translations for another language.
+
+1. Copy the English string resources
+   from [`res/values/strings.xml`](https://github.com/THEOplayer/android-ui/blob/main/ui/src/main/res/values/strings.xml)
+   to your app's resources for the default locale (i.e. `res/values/strings.xml`).
+2. Change the resource values to the translated texts.
+   For example, to change the title of the "Language" menu, you would change the contents
+   of the `theoplayer_ui_menu_language` resource:
+
+   ```xml title="res/values/strings.xml"
+   <resources>
+     <string name="theoplayer_ui_menu_language">Langue</string> <!-- translated to French -->
+   </resources>
+   ```
+
+   :::tip
+   You can also use
+   the [Translations Editor in Android Studio](https://developer.android.com/studio/write/translations-editor)
+   to edit these values.
+   :::
+
+3. Build and run your app. The translated texts should now appear in your player UI.
+
+## Add alternative languages {#add-alternative-languages}
+
+If your app targets many audiences speaking different languages, you can add multiple translations using
+locale-specific resources.
+
+1. Copy the English string resources
+   from [`res/values/strings.xml`](https://github.com/THEOplayer/android-ui/blob/main/ui/src/main/res/values/strings.xml)
+   to your app's resources for the default locale (i.e. `res/values/strings.xml`).
+2. Add a new string resources file for a new locale.
+   For example, for French, create the file: `res/values-fr/strings.xml`.
+3. Add translated versions for each English string resource to the new resources file.
+   For example, to translate the title of the "Language" menu, you would add an entry for `theoplayer_ui_menu_language`:
+   ```xml title="res/values-fr/strings.xml"
+   <resources>
+     <string name="theoplayer_ui_menu_language">Langue</string>
+   </resources>
+   ```
+
+## Remarks
+
+### Update translations when upgrading Open Video UI
+
+Newer versions of the Open Video UI for Android may add new string resources that need to be translated.
+
+When using custom translations in your app, we recommend pinning the `com.theoplayer.android-ui:android-ui` dependency
+in your app's `build.gradle` to a specific version. Avoid using `+` in the dependency's version range.
+
+```groovy title="build.gradle"
+dependencies {
+    implementation "com.theoplayer.android-ui:android-ui:1.9.0"
+}
+```
+
+When you decide to upgrade Open Video UI to the latest version, make sure to also update your translations.
+Check the history for [`res/values/strings.xml`](https://github.com/THEOplayer/android-ui/commits/main/ui/src/main/res/values/strings.xml)
+to see whether any string resources were added or changed since the previous version.
+
+## More information
+
+- [Localize your app on Android Developers](https://developer.android.com/guide/topics/resources/localization)
+- [Support different languages and cultures on Android Developers](https://developer.android.com/training/basics/supporting-devices/languages)

--- a/ui/src/main/java/com/theoplayer/android/ui/ChromecastButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/ChromecastButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.rounded.CastConnected
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.theoplayer.android.api.cast.chromecast.PlayerCastState
 
@@ -31,19 +32,19 @@ fun ChromecastButton(
     availableIcon: @Composable () -> Unit = {
         Icon(
             Icons.Rounded.Cast,
-            contentDescription = "Start casting"
+            contentDescription = stringResource(R.string.theoplayer_ui_btn_chromecast_start)
         )
     },
     connectingIcon: @Composable () -> Unit = {
         Icon(
             Icons.Rounded.Cast,
-            contentDescription = "Stop casting"
+            contentDescription = stringResource(R.string.theoplayer_ui_btn_chromecast_stop)
         )
     },
     connectedIcon: @Composable () -> Unit = {
         Icon(
             Icons.Rounded.CastConnected,
-            contentDescription = "Stop casting"
+            contentDescription = stringResource(R.string.theoplayer_ui_btn_chromecast_stop)
         )
     }
 ) {

--- a/ui/src/main/java/com/theoplayer/android/ui/ChromecastDisplay.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/ChromecastDisplay.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.theoplayer.android.api.cast.chromecast.PlayerCastState
 
@@ -68,7 +69,13 @@ fun ChromecastDisplayCompact(
         )
         Spacer(Modifier.size(ButtonDefaults.IconSpacing))
         Text(
-            text = "Playing on ${player.castReceiverName ?: "Chromecast"}"
+            text = player.castReceiverName?.let {
+                stringResource(
+                    R.string.theoplayer_ui_chromecast_playing_on_receiver,
+                    it
+                )
+            }
+                ?: stringResource(R.string.theoplayer_ui_chromecast_playing_on_unknown_receiver)
         )
     }
 }
@@ -101,11 +108,23 @@ fun ChromecastDisplayExpanded(
         }
         Column {
             Text(
-                text = "Playing on",
+                text = player.castReceiverName?.let {
+                    stringResource(
+                        R.string.theoplayer_ui_chromecast_playing_on_receiver_expanded_first_line,
+                        it
+                    )
+                }
+                    ?: stringResource(R.string.theoplayer_ui_chromecast_playing_on_unknown_receiver_expanded_first_line),
                 style = MaterialTheme.typography.bodyLarge
             )
             Text(
-                text = player.castReceiverName ?: "Chromecast",
+                text = player.castReceiverName?.let {
+                    stringResource(
+                        R.string.theoplayer_ui_chromecast_playing_on_receiver_expanded_second_line,
+                        it
+                    )
+                }
+                    ?: stringResource(R.string.theoplayer_ui_chromecast_playing_on_unknown_receiver_expanded_second_line),
                 style = MaterialTheme.typography.headlineSmall
             )
         }

--- a/ui/src/main/java/com/theoplayer/android/ui/CurrentTimeDisplay.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/CurrentTimeDisplay.kt
@@ -37,7 +37,7 @@ fun CurrentTimeDisplay(
             } else {
                 R.string.theoplayer_ui_current_time_with_duration
             },
-            formatTime(time, duration),
+            formatTime(time, duration, preferNegative = showRemaining),
             formatTime(duration)
         )
     } else {
@@ -47,7 +47,7 @@ fun CurrentTimeDisplay(
             } else {
                 R.string.theoplayer_ui_current_time
             },
-            formatTime(time, duration),
+            formatTime(time, duration, preferNegative = showRemaining),
         )
     }
 

--- a/ui/src/main/java/com/theoplayer/android/ui/CurrentTimeDisplay.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/CurrentTimeDisplay.kt
@@ -3,6 +3,7 @@ package com.theoplayer.android.ui
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 
 /**
  * A text display that shows the player's current time.
@@ -29,12 +30,26 @@ fun CurrentTimeDisplay(
         currentTime
     }
 
-    val text = StringBuilder()
-    text.append(formatTime(time, duration))
-    if (showDuration) {
-        text.append(" / ")
-        text.append(formatTime(duration))
+    val text = if (showDuration) {
+        stringResource(
+            if (showRemaining) {
+                R.string.theoplayer_ui_current_time_remaining_with_duration
+            } else {
+                R.string.theoplayer_ui_current_time_with_duration
+            },
+            formatTime(time, duration),
+            formatTime(duration)
+        )
+    } else {
+        stringResource(
+            if (showRemaining) {
+                R.string.theoplayer_ui_current_time_remaining
+            } else {
+                R.string.theoplayer_ui_current_time
+            },
+            formatTime(time, duration),
+        )
     }
 
-    Text(modifier = modifier, text = text.toString())
+    Text(modifier = modifier, text = text)
 }

--- a/ui/src/main/java/com/theoplayer/android/ui/DefaultUI.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/DefaultUI.kt
@@ -90,6 +90,7 @@ fun DefaultUI(
                     }
                     Spacer(modifier = Modifier.weight(1f))
                     LanguageMenuButton()
+                    SettingsMenuButton()
                     ChromecastButton()
                 }
             }

--- a/ui/src/main/java/com/theoplayer/android/ui/ErrorDisplay.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/ErrorDisplay.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 
 /**
@@ -43,7 +44,7 @@ fun ErrorDisplay(
                     contentAlignment = Alignment.CenterStart
                 ) {
                     Text(
-                        text = "An error occurred",
+                        text = stringResource(R.string.theoplayer_ui_error_title),
                         style = MaterialTheme.typography.headlineMedium
                     )
                 }

--- a/ui/src/main/java/com/theoplayer/android/ui/FullscreenButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/FullscreenButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.rounded.FullscreenExit
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 
 /**
@@ -25,13 +26,13 @@ fun FullscreenButton(
     enter: @Composable () -> Unit = {
         Icon(
             Icons.Rounded.Fullscreen,
-            contentDescription = "Enter fullscreen"
+            contentDescription = stringResource(R.string.theoplayer_ui_btn_fullscreen_enter)
         )
     },
     exit: @Composable () -> Unit = {
         Icon(
             Icons.Rounded.FullscreenExit,
-            contentDescription = "Exit fullscreen"
+            contentDescription = stringResource(R.string.theoplayer_ui_btn_fullscreen_exit)
         )
     }
 ) {

--- a/ui/src/main/java/com/theoplayer/android/ui/Helper.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/Helper.kt
@@ -1,5 +1,7 @@
 package com.theoplayer.android.ui
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import com.theoplayer.android.api.player.track.Track
 import java.util.Locale
 import kotlin.math.absoluteValue
@@ -60,6 +62,7 @@ fun formatTime(time: Double, guide: Double = 0.0, preferNegative: Boolean = fals
  *
  * @param track the media track or text track
  */
+@Composable
 fun formatTrackLabel(track: Track): String {
     val label = track.label
     if (!label.isNullOrEmpty()) {
@@ -74,5 +77,5 @@ fun formatTrackLabel(track: Track): String {
         }
         return languageCode
     }
-    return ""
+    return stringResource(R.string.theoplayer_ui_track_unknown)
 }

--- a/ui/src/main/java/com/theoplayer/android/ui/Helper.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/Helper.kt
@@ -18,7 +18,7 @@ import kotlin.math.absoluteValue
  * for example because it represents the time remaining in the video.
  */
 fun formatTime(time: Double, guide: Double = 0.0, preferNegative: Boolean = false): String {
-    val isNegative = time < 0 || (preferNegative && time == 0.0);
+    val isNegative = time < 0 || (preferNegative && time == 0.0)
     val absoluteTime = time.absoluteValue.toInt()
 
     val guideMinutes = ((guide / 60) % 60).toInt()

--- a/ui/src/main/java/com/theoplayer/android/ui/LanguageMenu.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/LanguageMenu.kt
@@ -88,7 +88,7 @@ fun MenuScope.LanguageMenuCompact() {
                         modifier = Modifier.weight(1f),
                         text = player?.activeAudioTrack?.let { formatTrackLabel(it) }
                             ?: stringResource(
-                                R.string.theoplayer_ui_menu_audio_none
+                                R.string.theoplayer_ui_audio_none
                             ),
                         textAlign = TextAlign.Center
                     )
@@ -116,7 +116,7 @@ fun MenuScope.LanguageMenuCompact() {
                     Text(
                         modifier = Modifier.weight(1f),
                         text = player?.activeSubtitleTrack?.let { formatTrackLabel(it) } ?: stringResource(
-                            R.string.theoplayer_ui_menu_subtitles_off
+                            R.string.theoplayer_ui_subtitles_off
                         ),
                         textAlign = TextAlign.Center
                     )

--- a/ui/src/main/java/com/theoplayer/android/ui/LanguageMenu.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/LanguageMenu.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
@@ -26,11 +27,11 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun MenuScope.LanguageMenu() {
     Menu(
-        title = { Text(text = "Language") },
+        title = { Text(text = stringResource(R.string.theoplayer_ui_menu_language)) },
         backIcon = {
             Icon(
                 Icons.Rounded.Close,
-                contentDescription = "Close"
+                contentDescription = stringResource(R.string.theoplayer_ui_btn_menu_close)
             )
         },
     ) {
@@ -75,7 +76,7 @@ fun MenuScope.LanguageMenuCompact() {
                     modifier = Modifier
                         .weight(1f)
                         .alignByBaseline(),
-                    text = "Audio"
+                    text = stringResource(R.string.theoplayer_ui_menu_audio)
                 )
                 TextButton(
                     modifier = Modifier
@@ -85,7 +86,10 @@ fun MenuScope.LanguageMenuCompact() {
                 ) {
                     Text(
                         modifier = Modifier.weight(1f),
-                        text = player?.activeAudioTrack?.let { formatTrackLabel(it) } ?: "None",
+                        text = player?.activeAudioTrack?.let { formatTrackLabel(it) }
+                            ?: stringResource(
+                                R.string.theoplayer_ui_menu_audio_none
+                            ),
                         textAlign = TextAlign.Center
                     )
                     Icon(
@@ -101,7 +105,7 @@ fun MenuScope.LanguageMenuCompact() {
                     modifier = Modifier
                         .weight(1f)
                         .alignByBaseline(),
-                    text = "Subtitles"
+                    text = stringResource(R.string.theoplayer_ui_menu_subtitles)
                 )
                 TextButton(
                     modifier = Modifier
@@ -111,7 +115,9 @@ fun MenuScope.LanguageMenuCompact() {
                 ) {
                     Text(
                         modifier = Modifier.weight(1f),
-                        text = player?.activeSubtitleTrack?.let { formatTrackLabel(it) } ?: "Off",
+                        text = player?.activeSubtitleTrack?.let { formatTrackLabel(it) } ?: stringResource(
+                            R.string.theoplayer_ui_menu_subtitles_off
+                        ),
                         textAlign = TextAlign.Center
                     )
                     Icon(
@@ -142,7 +148,7 @@ fun MenuScope.LanguageMenuExpanded() {
                     modifier = Modifier
                         .fillMaxWidth(1f)
                         .padding(0.dp, 8.dp),
-                    text = "Audio",
+                    text = stringResource(R.string.theoplayer_ui_menu_audio),
                     textAlign = TextAlign.Center,
                     style = MaterialTheme.typography.titleMedium
                 )
@@ -155,7 +161,7 @@ fun MenuScope.LanguageMenuExpanded() {
                     modifier = Modifier
                         .fillMaxWidth(1f)
                         .padding(0.dp, 8.dp),
-                    text = "Subtitles",
+                    text = stringResource(R.string.theoplayer_ui_menu_subtitles),
                     textAlign = TextAlign.Center,
                     style = MaterialTheme.typography.titleMedium
                 )
@@ -173,7 +179,7 @@ fun MenuScope.LanguageMenuExpanded() {
 @Composable
 fun MenuScope.AudioTrackMenu() {
     Menu(
-        title = { Text(text = "Audio") }
+        title = { Text(text = stringResource(R.string.theoplayer_ui_menu_audio)) }
     ) {
         AudioTrackList(onClick = { closeCurrentMenu() })
     }
@@ -187,7 +193,7 @@ fun MenuScope.AudioTrackMenu() {
 @Composable
 fun MenuScope.SubtitleMenu() {
     Menu(
-        title = { Text(text = "Subtitles") }
+        title = { Text(text = stringResource(R.string.theoplayer_ui_menu_subtitles)) }
     ) {
         SubtitleTrackList(onClick = { closeCurrentMenu() })
     }

--- a/ui/src/main/java/com/theoplayer/android/ui/LanguageMenuButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/LanguageMenuButton.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 
 /**
@@ -21,7 +22,7 @@ fun MenuScope.LanguageMenuButton(
     content: @Composable () -> Unit = {
         Icon(
             painter = painterResource(id = R.drawable.language),
-            contentDescription = "Language"
+            contentDescription = stringResource(R.string.theoplayer_ui_menu_language)
         )
     }
 ) {

--- a/ui/src/main/java/com/theoplayer/android/ui/LiveButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/LiveButton.kt
@@ -2,7 +2,9 @@ package com.theoplayer.android.ui
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Circle
 import androidx.compose.material3.ButtonColors
@@ -13,6 +15,7 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -43,20 +46,38 @@ fun LiveButton(
     live: @Composable RowScope.() -> Unit = {
         Icon(
             Icons.Rounded.Circle,
-            modifier = Modifier.size(12.dp),
+            modifier = Modifier
+                .size(12.dp)
+                .align(Alignment.CenterVertically),
             tint = THEOplayerTheme.playerColors.liveButtonLive,
             contentDescription = null
         )
-        Text(text = " " + stringResource(R.string.theoplayer_ui_btn_live))
+        Spacer(
+            modifier = Modifier
+                .width(4.dp)
+        )
+        Text(
+            modifier = Modifier.align(Alignment.CenterVertically),
+            text = stringResource(R.string.theoplayer_ui_btn_live)
+        )
     },
     dvr: @Composable RowScope. () -> Unit = {
         Icon(
             Icons.Rounded.Circle,
-            modifier = Modifier.size(12.dp),
+            modifier = Modifier
+                .size(12.dp)
+                .align(Alignment.CenterVertically),
             tint = THEOplayerTheme.playerColors.liveButtonDvr,
             contentDescription = null
         )
-        Text(text = " " + stringResource(R.string.theoplayer_ui_btn_live))
+        Spacer(
+            modifier = Modifier
+                .width(4.dp)
+        )
+        Text(
+            modifier = Modifier.align(Alignment.CenterVertically),
+            text = stringResource(R.string.theoplayer_ui_btn_live)
+        )
     }
 ) {
     val player = Player.current

--- a/ui/src/main/java/com/theoplayer/android/ui/LiveButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/LiveButton.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.theoplayer.android.ui.theme.THEOplayerTheme
 
@@ -46,7 +47,7 @@ fun LiveButton(
             tint = THEOplayerTheme.playerColors.liveButtonLive,
             contentDescription = null
         )
-        Text(text = " LIVE")
+        Text(text = " " + stringResource(R.string.theoplayer_ui_btn_live))
     },
     dvr: @Composable RowScope. () -> Unit = {
         Icon(
@@ -55,13 +56,14 @@ fun LiveButton(
             tint = THEOplayerTheme.playerColors.liveButtonDvr,
             contentDescription = null
         )
-        Text(text = " LIVE")
+        Text(text = " " + stringResource(R.string.theoplayer_ui_btn_live))
     }
 ) {
     val player = Player.current
     if (player?.streamType == StreamType.Live || player?.streamType == StreamType.Dvr) {
         val isLive =
-            !player.paused && ((player.seekable.lastEnd ?: 0.0) - player.currentTime) <= liveThreshold
+            !player.paused && ((player.seekable.lastEnd
+                ?: 0.0) - player.currentTime) <= liveThreshold
         TextButton(
             modifier = modifier,
             contentPadding = contentPadding,

--- a/ui/src/main/java/com/theoplayer/android/ui/Menu.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/Menu.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 
 /**
  * The content for a new menu, typically this should draw a single [Menu].
@@ -38,7 +39,7 @@ fun MenuScope.Menu(
     backIcon: @Composable () -> Unit = {
         Icon(
             Icons.AutoMirrored.Rounded.ArrowBack,
-            contentDescription = "Back"
+            contentDescription = stringResource(R.string.theoplayer_ui_btn_back)
         )
     },
     content: @Composable () -> Unit,

--- a/ui/src/main/java/com/theoplayer/android/ui/MuteButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/MuteButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 
 /**
@@ -25,13 +26,13 @@ fun MuteButton(
     mute: @Composable () -> Unit = {
         Icon(
             Icons.AutoMirrored.Rounded.VolumeUp,
-            contentDescription = "Mute"
+            contentDescription = stringResource(R.string.theoplayer_ui_btn_mute)
         )
     },
     unmute: @Composable () -> Unit = {
         Icon(
             Icons.AutoMirrored.Rounded.VolumeOff,
-            contentDescription = "Unmute"
+            contentDescription = stringResource(R.string.theoplayer_ui_btn_unmute)
         )
     }
 ) {

--- a/ui/src/main/java/com/theoplayer/android/ui/PlayButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/PlayButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 
 /**
@@ -29,21 +30,21 @@ fun PlayButton(
         Icon(
             painter = painterResource(id = R.drawable.play),
             modifier = iconModifier,
-            contentDescription = "Play"
+            contentDescription = stringResource(id = R.string.theoplayer_ui_btn_play)
         )
     },
     pause: @Composable () -> Unit = {
         Icon(
             painter = painterResource(id = R.drawable.pause),
             modifier = iconModifier,
-            contentDescription = "Pause"
+            contentDescription = stringResource(id = R.string.theoplayer_ui_btn_pause)
         )
     },
     replay: @Composable () -> Unit = {
         Icon(
             Icons.Rounded.Replay,
             modifier = iconModifier,
-            contentDescription = "Replay"
+            contentDescription = stringResource(id = R.string.theoplayer_ui_btn_replay)
         )
     }
 ) {

--- a/ui/src/main/java/com/theoplayer/android/ui/PlaybackRateList.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/PlaybackRateList.kt
@@ -6,7 +6,9 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import java.text.DecimalFormat
 
 /**
@@ -47,12 +49,13 @@ fun PlaybackRateList(
     }
 }
 
-private val playbackRateFormat = DecimalFormat("#.##")
-
+@Composable
 internal fun formatPlaybackRate(rate: Double): String {
     return if (rate == 1.0) {
-        "Normal"
+        stringResource(R.string.theoplayer_ui_playback_rate_normal, rate)
     } else {
-        "${playbackRateFormat.format(rate)}x"
+        val format = stringResource(R.string.theoplayer_ui_playback_rate_format)
+        val decimalFormat = remember(format) { DecimalFormat(format) }
+        decimalFormat.format(rate)
     }
 }

--- a/ui/src/main/java/com/theoplayer/android/ui/QualityList.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/QualityList.kt
@@ -6,7 +6,9 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import java.text.DecimalFormat
 
 /**
@@ -26,7 +28,7 @@ fun QualityList(
     LazyColumn(modifier = modifier) {
         item(key = null) {
             ListItem(
-                headlineContent = { Text(text = "Automatic") },
+                headlineContent = { Text(text = stringResource(R.string.theoplayer_ui_quality_automatic)) },
                 leadingContent = {
                     RadioButton(
                         selected = (targetVideoQuality == null),
@@ -45,7 +47,14 @@ fun QualityList(
         ) {
             val quality = videoQualities[it]
             ListItem(
-                headlineContent = { Text(text = "${quality.height}p") },
+                headlineContent = {
+                    Text(
+                        text = stringResource(
+                            R.string.theoplayer_ui_quality_with_height,
+                            quality.height
+                        )
+                    )
+                },
                 supportingContent = { Text(text = formatBandwidth(quality.bandwidth)) },
                 leadingContent = {
                     RadioButton(
@@ -62,15 +71,17 @@ fun QualityList(
     }
 }
 
-private val zeroPrecisionFormat = DecimalFormat("#")
-private val singlePrecisionFormat = DecimalFormat("#.#")
-
+@Composable
 internal fun formatBandwidth(bandwidth: Long): String {
-    return if (bandwidth > 1e7) {
-        "${zeroPrecisionFormat.format(bandwidth / 1e6)}Mbps"
-    } else if (bandwidth > 1e6) {
-        "${singlePrecisionFormat.format(bandwidth / 1e6)}Mbps"
-    } else {
-        "${zeroPrecisionFormat.format(bandwidth / 1e3)}kbps"
-    }
+    val format = stringResource(
+        if (bandwidth >= 1e7) {
+            R.string.theoplayer_ui_bandwidth_format_10mbps
+        } else if (bandwidth >= 1e6) {
+            R.string.theoplayer_ui_bandwidth_format_1mbps
+        } else {
+            R.string.theoplayer_ui_bandwidth_format_kbps
+        }
+    )
+    val decimalFormat = remember(format) { DecimalFormat(format) }
+    return decimalFormat.format(bandwidth / (if (bandwidth >= 1e6) 1e6 else 1e3))
 }

--- a/ui/src/main/java/com/theoplayer/android/ui/SeekButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SeekButton.kt
@@ -56,8 +56,8 @@ fun SeekButton(
                     } else {
                         R.plurals.theoplayer_ui_btn_seek_backward
                     },
-                    seekOffset,
-                    seekOffset
+                    seekOffset.absoluteValue,
+                    seekOffset.absoluteValue
                 )
             )
             Text(

--- a/ui/src/main/java/com/theoplayer/android/ui/SeekButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SeekButton.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -50,9 +51,9 @@ fun SeekButton(
                     .size(iconSize)
                     .scale(scaleX = if (seekOffset >= 0) -1f else 1f, scaleY = 1f),
                 contentDescription = if (seekOffset >= 0) {
-                    "Seek forward by $seekOffset seconds"
+                    stringResource(R.string.theoplayer_ui_btn_seek_forward, seekOffset)
                 } else {
-                    "Seek backward by $seekOffset seconds"
+                    stringResource(R.string.theoplayer_ui_btn_seek_backward, seekOffset)
                 }
             )
             Text(

--- a/ui/src/main/java/com/theoplayer/android/ui/SeekButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SeekButton.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -50,11 +50,15 @@ fun SeekButton(
                 modifier = Modifier
                     .size(iconSize)
                     .scale(scaleX = if (seekOffset >= 0) -1f else 1f, scaleY = 1f),
-                contentDescription = if (seekOffset >= 0) {
-                    stringResource(R.string.theoplayer_ui_btn_seek_forward, seekOffset)
-                } else {
-                    stringResource(R.string.theoplayer_ui_btn_seek_backward, seekOffset)
-                }
+                contentDescription = pluralStringResource(
+                    if (seekOffset >= 0) {
+                        R.plurals.theoplayer_ui_btn_seek_forward
+                    } else {
+                        R.plurals.theoplayer_ui_btn_seek_backward
+                    },
+                    seekOffset,
+                    seekOffset
+                )
             )
             Text(
                 modifier = Modifier

--- a/ui/src/main/java/com/theoplayer/android/ui/SettingsMenu.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SettingsMenu.kt
@@ -118,11 +118,22 @@ fun MenuScope.PlaybackRateMenu() {
     }
 }
 
+@Composable
 internal fun formatActiveQualityLabel(
     targetVideoQuality: VideoQuality?,
     activeVideoQuality: VideoQuality?
 ): String {
-    return targetVideoQuality?.let { "${it.height}p" }
-        ?: activeVideoQuality?.let { "Automatic (${it.height}p)" }
-        ?: "Automatic"
+    return if (targetVideoQuality != null) {
+        stringResource(
+            R.string.theoplayer_ui_quality_with_height,
+            targetVideoQuality.height
+        )
+    } else if (activeVideoQuality != null) {
+        stringResource(
+            R.string.theoplayer_ui_quality_automatic_with_height,
+            activeVideoQuality.height
+        )
+    } else {
+        stringResource(R.string.theoplayer_ui_quality_automatic)
+    }
 }

--- a/ui/src/main/java/com/theoplayer/android/ui/SettingsMenu.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SettingsMenu.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.theoplayer.android.api.player.track.mediatrack.quality.VideoQuality
@@ -24,11 +25,11 @@ import com.theoplayer.android.api.player.track.mediatrack.quality.VideoQuality
 @Composable
 fun MenuScope.SettingsMenu() {
     Menu(
-        title = { Text(text = "Settings") },
+        title = { Text(text = stringResource(R.string.theoplayer_ui_menu_settings)) },
         backIcon = {
             Icon(
                 Icons.Rounded.Close,
-                contentDescription = "Close"
+                contentDescription = stringResource(R.string.theoplayer_ui_btn_menu_close)
             )
         },
     ) {
@@ -39,7 +40,7 @@ fun MenuScope.SettingsMenu() {
                     modifier = Modifier
                         .weight(1f)
                         .alignByBaseline(),
-                    text = "Quality"
+                    text = stringResource(R.string.theoplayer_ui_menu_quality)
                 )
                 TextButton(
                     modifier = Modifier
@@ -66,7 +67,7 @@ fun MenuScope.SettingsMenu() {
                     modifier = Modifier
                         .weight(1f)
                         .alignByBaseline(),
-                    text = "Playback speed"
+                    text = stringResource(R.string.theoplayer_ui_menu_playback_rate)
                 )
                 TextButton(
                     modifier = Modifier
@@ -97,7 +98,7 @@ fun MenuScope.SettingsMenu() {
 @Composable
 fun MenuScope.QualityMenu() {
     Menu(
-        title = { Text(text = "Quality") }
+        title = { Text(text = stringResource(R.string.theoplayer_ui_menu_quality)) }
     ) {
         QualityList(onClick = { closeCurrentMenu() })
     }
@@ -111,7 +112,7 @@ fun MenuScope.QualityMenu() {
 @Composable
 fun MenuScope.PlaybackRateMenu() {
     Menu(
-        title = { Text(text = "Playback speed") }
+        title = { Text(text = stringResource(R.string.theoplayer_ui_menu_playback_rate)) }
     ) {
         PlaybackRateList(onClick = { closeCurrentMenu() })
     }

--- a/ui/src/main/java/com/theoplayer/android/ui/SettingsMenuButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SettingsMenuButton.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 
 /**
@@ -22,7 +23,7 @@ fun MenuScope.SettingsMenuButton(
     content: @Composable () -> Unit = {
         Icon(
             Icons.Rounded.Settings,
-            contentDescription = "Settings"
+            contentDescription = stringResource(R.string.theoplayer_ui_menu_settings)
         )
     }
 ) {

--- a/ui/src/main/java/com/theoplayer/android/ui/SubtitleTrackList.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/SubtitleTrackList.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 
 /**
  * A list of subtitle tracks, from which the user can choose an active subtitle track.
@@ -25,7 +26,7 @@ fun SubtitleTrackList(
     LazyColumn(modifier = modifier) {
         item(key = null) {
             ListItem(
-                headlineContent = { Text(text = "Off") },
+                headlineContent = { Text(text = stringResource(R.string.theoplayer_ui_subtitles_off)) },
                 leadingContent = {
                     RadioButton(
                         selected = (activeSubtitleTrack == null),

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -10,8 +10,14 @@
     <string name="theoplayer_ui_btn_back">Back</string>
     <string name="theoplayer_ui_btn_mute">Mute</string>
     <string name="theoplayer_ui_btn_unmute">Unmute</string>
-    <string name="theoplayer_ui_btn_seek_forward">Seek forward by %1$s seconds</string>
-    <string name="theoplayer_ui_btn_seek_backward">Seek backward by %1$s seconds</string>
+    <plurals name="theoplayer_ui_btn_seek_forward">
+        <item quantity="one">Seek forward by %1$s second</item>
+        <item quantity="other">Seek forward by %1$s seconds</item>
+    </plurals>
+    <plurals name="theoplayer_ui_btn_seek_backward">
+        <item quantity="one">Seek backward by %1$s second</item>
+        <item quantity="other">Seek backward by %1$s seconds</item>
+    </plurals>
     <string name="theoplayer_ui_btn_live">LIVE</string>
 
     <!-- The current time of the player -->

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1,1 +1,69 @@
-<resources></resources>
+<resources>
+    <string name="theoplayer_ui_btn_play">Play</string>
+    <string name="theoplayer_ui_btn_pause">Pause</string>
+    <string name="theoplayer_ui_btn_replay">Replay</string>
+    <string name="theoplayer_ui_btn_chromecast_start">Start casting</string>
+    <string name="theoplayer_ui_btn_chromecast_stop">Stop casting</string>
+    <string name="theoplayer_ui_btn_fullscreen_enter">Enter fullscreen</string>
+    <string name="theoplayer_ui_btn_fullscreen_exit">Exit fullscreen</string>
+    <string name="theoplayer_ui_btn_menu_close">Close</string>
+    <string name="theoplayer_ui_btn_back">Back</string>
+    <string name="theoplayer_ui_btn_mute">Mute</string>
+    <string name="theoplayer_ui_btn_unmute">Unmute</string>
+    <string name="theoplayer_ui_btn_seek_forward">Seek forward by %1$s seconds</string>
+    <string name="theoplayer_ui_btn_seek_backward">Seek backward by %1$s seconds</string>
+    <string name="theoplayer_ui_btn_live">LIVE</string>
+
+    <!-- The current time of the player -->
+    <string name="theoplayer_ui_current_time">%1$s</string>
+    <!-- The remaining time of the player -->
+    <string name="theoplayer_ui_current_time_remaining">%1$s</string>
+    <!-- The current time of the player, followed by the player's duration -->
+    <string name="theoplayer_ui_current_time_with_duration">%1$s / %2$s</string>
+    <!-- The remaining time of the player, followed by the player's duration -->
+    <string name="theoplayer_ui_current_time_remaining_with_duration">%1$s / %2$s</string>
+
+    <!--
+        The text shown on the player while connected to a Chromecast receiver with a known name.
+        Example: "Playing on Living Room", where "Living Room" is the name of the receiver.
+    -->
+    <string name="theoplayer_ui_chromecast_playing_on_receiver">Playing on %1$s</string>
+    <!-- Same as above, when the text is shown over two lines. -->
+    <string name="theoplayer_ui_chromecast_playing_on_receiver_expanded_first_line">Playing on</string>
+    <string name="theoplayer_ui_chromecast_playing_on_receiver_expanded_second_line">%1$s</string>
+    <!--
+        The text shown on the player while connected to a Chromecast receiver with an unknown name.
+    -->
+    <string name="theoplayer_ui_chromecast_playing_on_unknown_receiver">Playing on Chromecast</string>
+    <!-- Same as above, when the text is shown over two lines. -->
+    <string name="theoplayer_ui_chromecast_playing_on_unknown_receiver_expanded_first_line">Playing on</string>
+    <string name="theoplayer_ui_chromecast_playing_on_unknown_receiver_expanded_second_line">Chromecast</string>
+
+    <!-- The title of the language menu, where users can select an audio and subtitle language. -->
+    <string name="theoplayer_ui_menu_language">Language</string>
+    <!-- The title of the settings menu, where users can change e.g. the quality and playback speed. -->
+    <string name="theoplayer_ui_menu_settings">Settings</string>
+    <!-- The title of the audio language menu. -->
+    <string name="theoplayer_ui_menu_audio">Audio</string>
+    <!-- The label shown on the audio language dropdown to disable the audio. -->
+    <string name="theoplayer_ui_menu_audio_none">None</string>
+    <!-- The title of the subtitle menu. -->
+    <string name="theoplayer_ui_menu_subtitles">Subtitles</string>
+    <!-- The label shown on the subtitle dropdown to disable all subtitles. -->
+    <string name="theoplayer_ui_menu_subtitles_off">Off</string>
+    <!-- The title of the playback speed menu. -->
+    <string name="theoplayer_ui_menu_playback_rate">Playback speed</string>
+    <!-- The title of the quality selection menu. -->
+    <string name="theoplayer_ui_menu_quality">Quality</string>
+
+    <!-- The label shown for the normal playback speed (1x). -->
+    <string name="theoplayer_ui_playback_rate_normal">Normal</string>
+    <!--
+        The label shown for playback speeds different from the normal (1x) speed.
+        Must be a valid format string for java.text.DecimalFormat.
+    -->
+    <string name="theoplayer_ui_playback_rate_format">#.##x</string>
+
+    <!-- The title for a fatal error, shown above the full error message. -->
+    <string name="theoplayer_ui_error_title">An error occurred</string>
+</resources>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="theoplayer_ui_btn_play">Play</string>
     <string name="theoplayer_ui_btn_pause">Pause</string>
     <string name="theoplayer_ui_btn_replay">Replay</string>
@@ -11,35 +11,30 @@
     <string name="theoplayer_ui_btn_mute">Mute</string>
     <string name="theoplayer_ui_btn_unmute">Unmute</string>
     <plurals name="theoplayer_ui_btn_seek_forward">
-        <item quantity="one">Seek forward by %1$d second</item>
-        <item quantity="other">Seek forward by %1$d seconds</item>
+        <item quantity="one">Seek forward by <xliff:g example="5" id="seek_offset">%1$d</xliff:g> second</item>
+        <item quantity="other">Seek forward by <xliff:g example="5" id="seek_offset">%1$d</xliff:g> seconds</item>
     </plurals>
     <plurals name="theoplayer_ui_btn_seek_backward">
-        <item quantity="one">Seek backward by %1$d second</item>
-        <item quantity="other">Seek backward by %1$d seconds</item>
+        <item quantity="one">Seek backward by <xliff:g example="5" id="seek_offset">%1$d</xliff:g> second</item>
+        <item quantity="other">Seek backward by <xliff:g example="5" id="seek_offset">%1$d</xliff:g> seconds</item>
     </plurals>
     <string name="theoplayer_ui_btn_live">LIVE</string>
 
     <!-- The current time of the player -->
-    <string name="theoplayer_ui_current_time">%1$s</string>
+    <string name="theoplayer_ui_current_time"><xliff:g example="01:23" id="current_time">%1$s</xliff:g></string>
     <!-- The remaining time of the player -->
-    <string name="theoplayer_ui_current_time_remaining">%1$s</string>
+    <string name="theoplayer_ui_current_time_remaining"><xliff:g example="-01:23" id="remaining_time">%1$s</xliff:g></string>
     <!-- The current time of the player, followed by the player's duration -->
-    <string name="theoplayer_ui_current_time_with_duration">%1$s / %2$s</string>
+    <string name="theoplayer_ui_current_time_with_duration"><xliff:g example="01:23" id="current_time">%1$s</xliff:g> / <xliff:g example="60:00" id="duration">%2$s</xliff:g></string>
     <!-- The remaining time of the player, followed by the player's duration -->
-    <string name="theoplayer_ui_current_time_remaining_with_duration">%1$s / %2$s</string>
+    <string name="theoplayer_ui_current_time_remaining_with_duration"><xliff:g example="-01:23" id="remaining_time">%1$s</xliff:g> / <xliff:g example="60:00" id="duration">%2$s</xliff:g></string>
 
-    <!--
-        The text shown on the player while connected to a Chromecast receiver with a known name.
-        Example: "Playing on Living Room", where "Living Room" is the name of the receiver.
-    -->
-    <string name="theoplayer_ui_chromecast_playing_on_receiver">Playing on %1$s</string>
+    <!-- The text shown on the player while connected to a Chromecast receiver with a known name. -->
+    <string name="theoplayer_ui_chromecast_playing_on_receiver">Playing on <xliff:g example="Living Room" id="receiver_name">%1$s</xliff:g></string>
     <!-- Same as above, when the text is shown over two lines. -->
     <string name="theoplayer_ui_chromecast_playing_on_receiver_expanded_first_line">Playing on</string>
-    <string name="theoplayer_ui_chromecast_playing_on_receiver_expanded_second_line">%1$s</string>
-    <!--
-        The text shown on the player while connected to a Chromecast receiver with an unknown name.
-    -->
+    <string name="theoplayer_ui_chromecast_playing_on_receiver_expanded_second_line"><xliff:g example="Living Room" id="receiver_name">%1$s</xliff:g></string>
+    <!-- The text shown on the player while connected to a Chromecast receiver with an unknown name. -->
     <string name="theoplayer_ui_chromecast_playing_on_unknown_receiver">Playing on Chromecast</string>
     <!-- Same as above, when the text is shown over two lines. -->
     <string name="theoplayer_ui_chromecast_playing_on_unknown_receiver_expanded_first_line">Playing on</string>
@@ -73,11 +68,11 @@
     <string name="theoplayer_ui_playback_rate_format">#.##x</string>
 
     <!-- The label shown for a quality with a specified height (in pixels) -->
-    <string name="theoplayer_ui_quality_with_height">%1$dp</string>
+    <string name="theoplayer_ui_quality_with_height"><xliff:g example="720" id="quality_height">%1$d</xliff:g>p</string>
     <!-- The label shown for the automatic quality -->
     <string name="theoplayer_ui_quality_automatic">Automatic</string>
     <!-- The label shown for the automatic quality, along with the currently active quality's height (in pixels) -->
-    <string name="theoplayer_ui_quality_automatic_with_height">Automatic (%1$dp)</string>
+    <string name="theoplayer_ui_quality_automatic_with_height">Automatic (<xliff:g example="720" id="quality_height">%1$d</xliff:g>p)</string>
 
     <!--
         The label shown for bandwidths larger than 10 Mbps.

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -45,16 +45,18 @@
     <string name="theoplayer_ui_menu_settings">Settings</string>
     <!-- The title of the audio language menu. -->
     <string name="theoplayer_ui_menu_audio">Audio</string>
-    <!-- The label shown on the audio language dropdown to disable the audio. -->
-    <string name="theoplayer_ui_menu_audio_none">None</string>
     <!-- The title of the subtitle menu. -->
     <string name="theoplayer_ui_menu_subtitles">Subtitles</string>
-    <!-- The label shown on the subtitle dropdown to disable all subtitles. -->
-    <string name="theoplayer_ui_menu_subtitles_off">Off</string>
     <!-- The title of the playback speed menu. -->
     <string name="theoplayer_ui_menu_playback_rate">Playback speed</string>
     <!-- The title of the quality selection menu. -->
     <string name="theoplayer_ui_menu_quality">Quality</string>
+
+    <!-- The label shown on the audio language dropdown to disable the audio. -->
+    <string name="theoplayer_ui_audio_none">None</string>
+
+    <!-- The label shown on the subtitle dropdown to disable all subtitles. -->
+    <string name="theoplayer_ui_subtitles_off">Off</string>
 
     <!-- The label shown for the normal playback speed (1x). -->
     <string name="theoplayer_ui_playback_rate_normal">Normal</string>
@@ -63,6 +65,23 @@
         Must be a valid format string for java.text.DecimalFormat.
     -->
     <string name="theoplayer_ui_playback_rate_format">#.##x</string>
+
+    <!-- The label shown for a quality with a specified height (in pixels) -->
+    <string name="theoplayer_ui_quality_with_height">%1$sp</string>
+    <!-- The label shown for the automatic quality -->
+    <string name="theoplayer_ui_quality_automatic">Automatic</string>
+    <!-- The label shown for the automatic quality, along with the currently active quality's height (in pixels) -->
+    <string name="theoplayer_ui_quality_automatic_with_height">Automatic (%1$sp)</string>
+
+    <!-- The label shown for bandwidths larger than 10 Mbps. -->
+    <string name="theoplayer_ui_bandwidth_format_10mbps">#Mbps</string>
+    <!-- The label shown for bandwidths between 1 Mbps and 10 Mbps. -->
+    <string name="theoplayer_ui_bandwidth_format_1mbps">#.#Mbps</string>
+    <!-- The label shown for bandwidths below 1 Mbps. -->
+    <string name="theoplayer_ui_bandwidth_format_kbps">#kbps</string>
+
+    <!-- The label shown for an audio or subtitle track with an unspecified name or language. -->
+    <string name="theoplayer_ui_track_unknown">Unknown</string>
 
     <!-- The title for a fatal error, shown above the full error message. -->
     <string name="theoplayer_ui_error_title">An error occurred</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+<resources xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" tools:locale="en">
     <string name="theoplayer_ui_btn_play">Play</string>
     <string name="theoplayer_ui_btn_pause">Pause</string>
     <string name="theoplayer_ui_btn_replay">Replay</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -11,12 +11,12 @@
     <string name="theoplayer_ui_btn_mute">Mute</string>
     <string name="theoplayer_ui_btn_unmute">Unmute</string>
     <plurals name="theoplayer_ui_btn_seek_forward">
-        <item quantity="one">Seek forward by %1$s second</item>
-        <item quantity="other">Seek forward by %1$s seconds</item>
+        <item quantity="one">Seek forward by %1$d second</item>
+        <item quantity="other">Seek forward by %1$d seconds</item>
     </plurals>
     <plurals name="theoplayer_ui_btn_seek_backward">
-        <item quantity="one">Seek backward by %1$s second</item>
-        <item quantity="other">Seek backward by %1$s seconds</item>
+        <item quantity="one">Seek backward by %1$d second</item>
+        <item quantity="other">Seek backward by %1$d seconds</item>
     </plurals>
     <string name="theoplayer_ui_btn_live">LIVE</string>
 
@@ -73,17 +73,26 @@
     <string name="theoplayer_ui_playback_rate_format">#.##x</string>
 
     <!-- The label shown for a quality with a specified height (in pixels) -->
-    <string name="theoplayer_ui_quality_with_height">%1$sp</string>
+    <string name="theoplayer_ui_quality_with_height">%1$dp</string>
     <!-- The label shown for the automatic quality -->
     <string name="theoplayer_ui_quality_automatic">Automatic</string>
     <!-- The label shown for the automatic quality, along with the currently active quality's height (in pixels) -->
-    <string name="theoplayer_ui_quality_automatic_with_height">Automatic (%1$sp)</string>
+    <string name="theoplayer_ui_quality_automatic_with_height">Automatic (%1$dp)</string>
 
-    <!-- The label shown for bandwidths larger than 10 Mbps. -->
+    <!--
+        The label shown for bandwidths larger than 10 Mbps.
+        Must be a valid format string for java.text.DecimalFormat.
+     -->
     <string name="theoplayer_ui_bandwidth_format_10mbps">#Mbps</string>
-    <!-- The label shown for bandwidths between 1 Mbps and 10 Mbps. -->
+    <!--
+        The label shown for bandwidths between 1 Mbps and 10 Mbps.
+        Must be a valid format string for java.text.DecimalFormat.
+    -->
     <string name="theoplayer_ui_bandwidth_format_1mbps">#.#Mbps</string>
-    <!-- The label shown for bandwidths below 1 Mbps. -->
+    <!--
+        The label shown for bandwidths below 1 Mbps.
+        Must be a valid format string for java.text.DecimalFormat.
+    -->
     <string name="theoplayer_ui_bandwidth_format_kbps">#kbps</string>
 
     <!-- The label shown for an audio or subtitle track with an unspecified name or language. -->


### PR DESCRIPTION
Move all texts to string resources, so they can be translated by a customer in their own app's resources. Also write some documentation on how to translate these texts.

Other improvements:
* Prefer negative times when showing the remaining time in `CurrentTimeDisplay`.
* Make the icon and text of the `LiveButton` properly vertically centered.