### PR TITLE
Revert to compileSdk 34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 🐛 Revert to `compileSdk` 34. ([#56](https://github.com/THEOplayer/android-ui/pull/56/))
+
 ## v1.9.3 (2024-12-17)
 
 * 💥 Updated to Jetpack Compose version 1.7.5 ([BOM](https://developer.android.com/jetpack/compose/bom) 2024.11.00).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace = "com.theoplayer.android.ui.demo"
-    compileSdk = 35
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.theoplayer.android.ui.demo"
         minSdk = 21
-        targetSdk = 35
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 gradle = "8.7.3"
 kotlin-gradle-plugin = "1.9.25"
-ktx = "1.15.0"
+ktx = "1.13.1"
 lifecycle-compose = "2.8.7"
 activity-compose = "1.9.3"
 appcompat = "1.7.0"

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 android {
     namespace = "com.theoplayer.android.ui"
-    compileSdk = 35
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 21


### PR DESCRIPTION
THEOplayer itself still compiles against API 34, and isn't yet ready to upgrade to 35. Revert for now.