### PR TITLE
Add support for THEOplayer 9.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 🚀 Added support for THEOplayer 9.0. ([#61](https://github.com/THEOplayer/android-ui/pulls/61))
+
 ## v1.9.4 (2024-12-18)
 
 * 🐛 Revert to `compileSdk` 34. ([#56](https://github.com/THEOplayer/android-ui/pull/56/))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 
 ## v1.8.0 (2024-09-06)
 
-* 🚀 Added support for THEOplayer 8.0.
+* 🚀 Added support for THEOplayer 8.0. ([#37](https://github.com/THEOplayer/android-ui/pulls/37))
 
 ## v1.7.4 (2024-09-02)
 

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -84,7 +84,7 @@ dependencies {
 
     implementation(libs.theoplayer) {
         version {
-            strictly("[5.0, 9.0)")
+            strictly("[5.0, 10.0)")
         }
     }
 


### PR DESCRIPTION
Open Video UI is not affected by any of the breaking changes, so this is just a simple version bump.