### PR TITLE
Bump compileSdk and targetSdk to API 35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Unreleased
 
+* 💥 Bumped `compileSdk` to API 35 (Android 15).
 * 🚀 Added localization support.
   * See `res/values/strings.xml` for the full list of translatable strings, which you can override in your app's `strings.xml`.
   * For more information, see [Localize your app on Android Developers](https://developer.android.com/guide/topics/resources/localization).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace = "com.theoplayer.android.ui.demo"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.theoplayer.android.ui.demo"
         minSdk = 21
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ androidx-junit = "1.2.1"
 androidx-espresso = "3.6.1"
 androidx-mediarouter = "1.7.0"
 dokka = "2.0.0"
-theoplayer = "8.6.2"
+theoplayer = "9.2.0"
 
 [libraries]
 androidx-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 
 android {
     namespace = "com.theoplayer.android.ui"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 21


### PR DESCRIPTION
THEOplayer 9.x requires `compileSdk` 35 or higher, so bump it in Open Video UI too.