### PR TITLE
Fix clickthroughs from ads and overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 🐛 Fixed clicking on overlays from OptiView Ads not working. ([#68](https://github.com/THEOplayer/android-ui/pull/68))
+
 ## v1.11.0 (2025-04-29)
 
 * 💥 Bumped `compileSdk` to API 35 (Android 15).

--- a/ui/src/main/java/com/theoplayer/android/ui/Modifiers.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/Modifiers.kt
@@ -1,28 +1,11 @@
 package com.theoplayer.android.ui
 
 import androidx.annotation.FloatRange
-import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.gestures.waitForUpOrCancellation
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.PressInteraction
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.pointer.AwaitPointerEventScope
 import androidx.compose.ui.input.pointer.PointerEventPass
-import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.PointerInputScope
-import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
-import androidx.compose.ui.input.pointer.isOutOfBounds
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.IntrinsicMeasurable
 import androidx.compose.ui.layout.IntrinsicMeasureScope
@@ -41,94 +24,6 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
-
-internal fun Modifier.pressable(
-    interactionSource: MutableInteractionSource,
-    enabled: Boolean = true,
-    requireUnconsumed: Boolean = true
-): Modifier = composed(
-    inspectorInfo = debugInspectorInfo {
-        name = "pressable"
-        properties["interactionSource"] = interactionSource
-        properties["enabled"] = enabled
-        properties["requireUnconsumed"] = requireUnconsumed
-    }
-) {
-    val scope = rememberCoroutineScope()
-    var pressedInteraction by remember { mutableStateOf<PressInteraction.Press?>(null) }
-
-    suspend fun emitPress(pressPosition: Offset) {
-        if (pressedInteraction == null) {
-            val interaction = PressInteraction.Press(pressPosition)
-            interactionSource.emit(interaction)
-            pressedInteraction = interaction
-        }
-    }
-
-    suspend fun emitRelease() {
-        pressedInteraction?.let { oldValue ->
-            val interaction = PressInteraction.Release(oldValue)
-            interactionSource.emit(interaction)
-            pressedInteraction = null
-        }
-    }
-
-    fun tryEmitCancel() {
-        pressedInteraction?.let { oldValue ->
-            val interaction = PressInteraction.Cancel(oldValue)
-            interactionSource.tryEmit(interaction)
-            pressedInteraction = null
-        }
-    }
-
-    DisposableEffect(interactionSource) {
-        onDispose { tryEmitCancel() }
-    }
-    LaunchedEffect(enabled) {
-        if (!enabled) {
-            emitRelease()
-        }
-    }
-
-    if (enabled) {
-        Modifier
-            .pointerInput(interactionSource) {
-                val currentContext = currentCoroutineContext()
-                awaitPointerEventScope {
-                    while (currentContext.isActive) {
-                        val down = awaitFirstDown(requireUnconsumed = requireUnconsumed)
-                        scope.launch { emitPress(down.position) }
-                        val up =
-                            if (requireUnconsumed) waitForUpOrCancellation() else waitForUpOrCancellationIgnoreConsumed()
-                        if (up == null) {
-                            tryEmitCancel()
-                        } else {
-                            scope.launch { emitRelease() }
-                        }
-                    }
-                }
-            }
-    } else {
-        Modifier
-    }
-}
-
-/**
- * Like [AwaitPointerEventScope.waitForUpOrCancellation],
- * but skips the [PointerInputChange.isConsumed] checks.
- */
-private suspend fun AwaitPointerEventScope.waitForUpOrCancellationIgnoreConsumed(): PointerInputChange? {
-    while (true) {
-        val event = awaitPointerEvent(PointerEventPass.Main)
-        if (event.changes.all { it.changedToUpIgnoreConsumed() }) {
-            // All pointers are up
-            return event.changes[0]
-        }
-        if (event.changes.any { it.isOutOfBounds(size, extendedTouchPadding) }) {
-            return null // Canceled
-        }
-    }
-}
 
 internal fun Modifier.toggleControlsOnTap(
     controlsVisible: State<Boolean>,

--- a/ui/src/main/java/com/theoplayer/android/ui/Player.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/Player.kt
@@ -6,6 +6,8 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableDoubleStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -296,9 +298,9 @@ enum class StreamType {
 internal class PlayerImpl(override val theoplayerView: THEOplayerView?) : Player {
     override val player = theoplayerView?.player
     override val ads = theoplayerView?.player?.ads
-    override var currentTime by mutableStateOf(0.0)
+    override var currentTime by mutableDoubleStateOf(0.0)
         private set
-    override var duration by mutableStateOf(Double.NaN)
+    override var duration by mutableDoubleStateOf(Double.NaN)
         private set
     override var seekable by mutableStateOf(TimeRanges.empty())
         private set
@@ -312,9 +314,9 @@ internal class PlayerImpl(override val theoplayerView: THEOplayerView?) : Player
         private set
     override var readyState by mutableStateOf(ReadyState.HAVE_NOTHING)
         private set
-    override var videoWidth by mutableStateOf(0)
+    override var videoWidth by mutableIntStateOf(0)
         private set
-    override var videoHeight by mutableStateOf(0)
+    override var videoHeight by mutableIntStateOf(0)
         private set
     override var firstPlay by mutableStateOf(false)
         private set
@@ -401,7 +403,7 @@ internal class PlayerImpl(override val theoplayerView: THEOplayerView?) : Player
             player?.source = value
         }
 
-    private var _volume by mutableStateOf(1.0)
+    private var _volume by mutableDoubleStateOf(1.0)
     private var _muted by mutableStateOf(false)
     override var volume: Double
         get() = _volume
@@ -423,7 +425,7 @@ internal class PlayerImpl(override val theoplayerView: THEOplayerView?) : Player
 
     private val volumeChangeListener = EventListener<VolumeChangeEvent> { updateVolumeAndMuted() }
 
-    private var _playbackRate by mutableStateOf(1.0)
+    private var _playbackRate by mutableDoubleStateOf(1.0)
     override var playbackRate: Double
         get() = _playbackRate
         set(value) {

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -17,9 +17,6 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
-import androidx.compose.foundation.interaction.Interaction
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -69,9 +66,6 @@ import kotlin.time.DurationUnit
  * @param modifier the [Modifier] to be applied to this container
  * @param config the player configuration to be used when constructing the [THEOplayerView]
  * @param source the source description to load into the player
- * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
- * for this container. You can create and pass in your own `remember`ed instance to observe
- * [Interaction]s and customize the behavior of this container.
  * @param color the background color for the overlay while showing the UI controls
  * @param centerOverlay content to show in the center of the player, typically a [LoadingSpinner].
  * @param errorOverlay content to show when the player encountered a fatal error,
@@ -86,7 +80,6 @@ fun UIController(
     modifier: Modifier = Modifier,
     config: THEOplayerConfig,
     source: SourceDescription? = null,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     color: Color = Color.Black,
     centerOverlay: (@Composable UIControllerScope.() -> Unit)? = null,
     errorOverlay: (@Composable UIControllerScope.() -> Unit)? = null,
@@ -102,7 +95,6 @@ fun UIController(
     UIController(
         modifier = modifier,
         player = player,
-        interactionSource = interactionSource,
         color = color,
         centerOverlay = centerOverlay,
         errorOverlay = errorOverlay,
@@ -121,9 +113,6 @@ fun UIController(
  *
  * @param modifier the [Modifier] to be applied to this container
  * @param player the player. This should always be created using [rememberPlayer].
- * @param interactionSource the [MutableInteractionSource] representing the stream of [Interaction]s
- * for this container. You can create and pass in your own `remember`ed instance to observe
- * [Interaction]s and customize the behavior of this container.
  * @param color the background color for the overlay while showing the UI controls
  * @param centerOverlay content to show in the center of the player, typically a [LoadingSpinner].
  * @param errorOverlay content to show when the player encountered a fatal error,
@@ -137,7 +126,6 @@ fun UIController(
 fun UIController(
     modifier: Modifier = Modifier,
     player: Player = rememberPlayer(),
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     color: Color = Color.Black,
     centerOverlay: (@Composable UIControllerScope.() -> Unit)? = null,
     errorOverlay: (@Composable UIControllerScope.() -> Unit)? = null,
@@ -154,7 +142,6 @@ fun UIController(
             isRecentlyTapped = false
         }
     }
-    val isPressed by interactionSource.collectIsPressedAsState()
     var forceControlsHidden by remember { mutableStateOf(false) }
 
     // Wait a little bit before showing the controls and enabling animations,
@@ -176,7 +163,7 @@ fun UIController(
             } else if (forceControlsHidden) {
                 false
             } else {
-                isRecentlyTapped || isPressed || player.paused
+                isRecentlyTapped || player.paused
             }
         }
     }
@@ -220,7 +207,6 @@ fun UIController(
     PlayerContainer(
         player = player,
         modifier = modifier
-            .pressable(interactionSource = interactionSource, requireUnconsumed = false)
             .toggleControlsOnTap(
                 controlsVisible = controlsVisible,
                 showControlsTemporarily = {

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -217,7 +217,21 @@ fun UIController(
         )
     )
 
-    PlayerContainer(modifier = modifier, player = player) {
+    PlayerContainer(
+        player = player,
+        modifier = modifier
+            .pressable(interactionSource = interactionSource, requireUnconsumed = false)
+            .toggleControlsOnTap(
+                controlsVisible = controlsVisible,
+                showControlsTemporarily = {
+                    forceControlsHidden = false
+                    tapCount++
+                },
+                hideControls = {
+                    forceControlsHidden = true
+                    tapCount++
+                })
+    ) {
         CompositionLocalProvider(LocalPlayer provides player) {
             if (player.playingAd) {
                 // Remove player UI entirely while playing an ad, to make clickthrough work
@@ -226,18 +240,7 @@ fun UIController(
             AnimatedContent(
                 label = "ContentAnimation",
                 modifier = Modifier
-                    .background(background)
-                    .pressable(interactionSource = interactionSource, requireUnconsumed = false)
-                    .toggleControlsOnTap(
-                        controlsVisible = controlsVisible,
-                        showControlsTemporarily = {
-                            forceControlsHidden = false
-                            tapCount++
-                        },
-                        hideControls = {
-                            forceControlsHidden = true
-                            tapCount++
-                        }),
+                    .background(background),
                 targetState = uiState,
                 transitionSpec = {
                     if (targetState is UIState.Error) {

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -206,7 +206,10 @@ fun UIController(
 
     PlayerContainer(
         player = player,
-        modifier = modifier
+        modifier = Modifier
+            .background(Color.Black)
+            .then(modifier)
+            .playerAspectRatio(player)
             .toggleControlsOnTap(
                 controlsVisible = controlsVisible,
                 showControlsTemporarily = {
@@ -216,7 +219,8 @@ fun UIController(
                 hideControls = {
                     forceControlsHidden = true
                     tapCount++
-                })
+                }
+            )
     ) {
         CompositionLocalProvider(LocalPlayer provides player) {
             AnimatedContent(
@@ -318,13 +322,9 @@ private fun PlayerContainer(
     ui: @Composable () -> Unit
 ) {
     val theoplayerView = player.theoplayerView
-    val containerModifier = Modifier
-        .background(Color.Black)
-        .then(modifier)
-        .playerAspectRatio(player)
     if (theoplayerView == null) {
         Box(
-            modifier = containerModifier
+            modifier = modifier
         ) {
             ui()
         }
@@ -334,7 +334,7 @@ private fun PlayerContainer(
         var composeView by remember { mutableStateOf<ComposeView?>(null) }
 
         AndroidView(
-            modifier = containerModifier,
+            modifier = modifier,
             factory = { context ->
                 uiContainer =
                     theoplayerView.findViewById(com.theoplayer.android.R.id.theo_ui_container)

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -233,10 +233,6 @@ fun UIController(
                 })
     ) {
         CompositionLocalProvider(LocalPlayer provides player) {
-            if (player.playingAd) {
-                // Remove player UI entirely while playing an ad, to make clickthrough work
-                return@CompositionLocalProvider
-            }
             AnimatedContent(
                 label = "ContentAnimation",
                 modifier = Modifier

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -144,7 +145,7 @@ fun UIController(
     centerChrome: (@Composable UIControllerScope.() -> Unit)? = null,
     bottomChrome: (@Composable UIControllerScope.() -> Unit)? = null
 ) {
-    var tapCount by remember { mutableStateOf(0) }
+    var tapCount by remember { mutableIntStateOf(0) }
     var isRecentlyTapped by remember { mutableStateOf(false) }
     LaunchedEffect(tapCount) {
         if (tapCount > 0) {


### PR DESCRIPTION
Previously, ads and overlays inserted by OptiView Ads were not properly clickable when using Open Video UI. This made them quite useless, since advertisers want interested viewers to be able to visit their website.

The problem is that we registered our tap detection handlers on the `AnimatedContent` *within* the `ComposeView`. This view ends up being hosted inside the `THEOplayerView`'s `theo_ui_container`, which is placed inside a `FrameLayout` above the content and ad player. That means that if the `ComposeView` "handles" the touch event, the `FrameLayout` will not pass it to any children lower down the stack, so the ad player never receives the touch event.

Instead, we now register our tap detection handlers on the `PlayerContainer`, which holds an `AndroidView` that hosts the entire `THEOplayerView`. Now, when the `THEOplayerView` is touched, this is what happens:
1. Since `THEOplayerView` is a `FrameLayout`, it first tries to pass the event to the top-most `View`, which is our `ComposeView` holding the UI.
1.1. If the touch hits a UI button, then this handles the event. Stop.
1.2. If the touch does not hit any UI buttons, then this does not handle the event. We continue to the next `View` in the stack.
2. The next `View` is the ad player.
2.1. If the touch hits the ad clickthrough button, then the ad player opens the browser and handles the event. Stop.
2.2. If the touch does not hit the ad clickthrough button, then this does not handle the event.
3. The next `View` is the content player. This usually doesn't have any touchable targets, so we continue.
4. We've now gone through all `View` inside `THEOplayerView` without handling the touch event, so we pass it onto the parent instead. This is the `AndroidView`, which again passes it to its parent.
5. Finally, we reach the parent `PlayerContainer`. Here, we can detect the tap and show/hide the UI controls. Note that we still don't mark the touch event as handled, in case any other parent view wants to continue handling it.

This is a much more robust solution, since we handle the touch event *after* everything else inside the `THEOplayerView` has had a chance to handle it. 🙂