### PR TITLE
Add picture-in-picture button

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"
-            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
+            android:supportsPictureInPicture="true"
+            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation|keyboardHidden"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.THEOplayerAndroidUI">

--- a/app/src/main/java/com/theoplayer/android/ui/demo/MainActivity.kt
+++ b/app/src/main/java/com/theoplayer/android/ui/demo/MainActivity.kt
@@ -30,6 +30,7 @@ import com.theoplayer.android.api.ads.ima.GoogleImaIntegrationFactory
 import com.theoplayer.android.api.cast.CastConfiguration
 import com.theoplayer.android.api.cast.CastIntegrationFactory
 import com.theoplayer.android.api.cast.CastStrategy
+import com.theoplayer.android.api.pip.PipConfiguration
 import com.theoplayer.android.ui.DefaultUI
 import com.theoplayer.android.ui.demo.nitflex.NitflexUI
 import com.theoplayer.android.ui.demo.nitflex.theme.NitflexTheme
@@ -59,7 +60,10 @@ fun MainContent() {
 
     val context = LocalContext.current
     val theoplayerView = remember(context) {
-        THEOplayerView(context).apply {
+        val config = THEOplayerConfig.Builder().apply {
+            pipConfiguration(PipConfiguration.Builder().build())
+        }.build()
+        THEOplayerView(context, config).apply {
             // Add ads integration through Google IMA
             player.addIntegration(
                 GoogleImaIntegrationFactory.createGoogleImaIntegration(this)

--- a/app/src/main/java/com/theoplayer/android/ui/demo/Streams.kt
+++ b/app/src/main/java/com/theoplayer/android/ui/demo/Streams.kt
@@ -11,6 +11,13 @@ data class Stream(val title: String, val source: SourceDescription)
 val streams by lazy {
     listOf(
         Stream(
+            title = "Bip Bop (HLS)",
+            source = SourceDescription.Builder(
+                TypedSource.Builder("https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8")
+                    .build()
+            ).build()
+        ),
+        Stream(
             title = "Elephant's Dream (HLS)",
             source = SourceDescription.Builder(
                 TypedSource.Builder("https://cdn.theoplayer.com/video/elephants-dream/playlist.m3u8")

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -39,4 +39,7 @@
     <string name="theoplayer_ui_quality_automatic_with_height">Automatisch (%1$dp)</string>
     <string name="theoplayer_ui_track_unknown">Onbekend</string>
     <string name="theoplayer_ui_error_title">Fout</string>
+    <string name="theoplayer_ui_pip_enter">Start picture-in-picture</string>
+    <string name="theoplayer_ui_pip_exit">Stop picture-in-picture</string>
+    <string name="theo_pip_placeholder">Video speelt in PiP.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,4 +50,7 @@
     <string name="theoplayer_ui_bandwidth_format_kbps" translatable="false">#kbps</string>
     <string name="theoplayer_ui_track_unknown">Unknown</string>
     <string name="theoplayer_ui_error_title">An error occurred</string>
+    <string name="theoplayer_ui_pip_enter">Enter picture-in-picture</string>
+    <string name="theoplayer_ui_pip_exit">Exit picture-in-picture</string>
+    <string name="theo_pip_placeholder">Video playing in PiP mode.</string>
 </resources>

--- a/ui/src/main/java/com/theoplayer/android/ui/DefaultUI.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/DefaultUI.kt
@@ -80,7 +80,7 @@ fun DefaultUI(
             }
         },
         topChrome = {
-            if (player.firstPlay) {
+            if (player.firstPlay && !player.pictureInPicture) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     title?.let {
                         Text(
@@ -120,6 +120,7 @@ fun DefaultUI(
                         )
                     }
                     Spacer(modifier = Modifier.weight(1f))
+                    PictureInPictureButton()
                     FullscreenButton()
                 }
             }

--- a/ui/src/main/java/com/theoplayer/android/ui/PictureInPictureButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/PictureInPictureButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.rounded.PictureInPictureAlt
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.theoplayer.android.api.pip.PiPType
 
@@ -30,13 +31,13 @@ fun PictureInPictureButton(
     enter: @Composable () -> Unit = {
         Icon(
             Icons.Rounded.PictureInPictureAlt,
-            contentDescription = "Enter picture-in-picture"
+            contentDescription = stringResource(R.string.theoplayer_ui_pip_enter),
         )
     },
     exit: @Composable () -> Unit = {
         Icon(
             Icons.Rounded.Fullscreen,
-            contentDescription = "Exit picture-in-picture"
+            contentDescription = stringResource(R.string.theoplayer_ui_pip_exit)
         )
     }
 ) {

--- a/ui/src/main/java/com/theoplayer/android/ui/PictureInPictureButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/PictureInPictureButton.kt
@@ -41,6 +41,7 @@ fun PictureInPictureButton(
     }
 ) {
     val player = Player.current
+    if (player?.pictureInPictureSupported != true) return
     IconButton(
         modifier = modifier,
         contentPadding = contentPadding,

--- a/ui/src/main/java/com/theoplayer/android/ui/PictureInPictureButton.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/PictureInPictureButton.kt
@@ -1,0 +1,62 @@
+package com.theoplayer.android.ui
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Fullscreen
+import androidx.compose.material.icons.rounded.PictureInPictureAlt
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.theoplayer.android.api.pip.PiPType
+
+/**
+ * A button that toggles picture-in-picture mode.
+ *
+ * @param modifier the [Modifier] to be applied to this button
+ * @param contentPadding the spacing values to apply internally between the container
+ *        and the content
+ * @param pipType the type of the picture-in-picture window when entering
+ * @param enter button content when the player is not in picture-in-picture mode,
+ *        typically an "enter picture-in-picture" icon
+ * @param exit button content when the player is in picture-in-picture mode,
+ *        typically an "exit picture-in-picture" icon
+ */
+@Composable
+fun PictureInPictureButton(
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    pipType: PiPType = PiPType.ACTIVITY,
+    enter: @Composable () -> Unit = {
+        Icon(
+            Icons.Rounded.PictureInPictureAlt,
+            contentDescription = "Enter picture-in-picture"
+        )
+    },
+    exit: @Composable () -> Unit = {
+        Icon(
+            Icons.Rounded.Fullscreen,
+            contentDescription = "Exit picture-in-picture"
+        )
+    }
+) {
+    val player = Player.current
+    IconButton(
+        modifier = modifier,
+        contentPadding = contentPadding,
+        onClick = {
+            player?.let {
+                if (it.pictureInPicture) {
+                    it.exitPictureInPicture()
+                } else {
+                    it.enterPictureInPicture(pipType)
+                }
+            }
+        }) {
+        if (player?.pictureInPicture == true) {
+            exit()
+        } else {
+            enter()
+        }
+    }
+}

--- a/ui/src/main/java/com/theoplayer/android/ui/Player.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/Player.kt
@@ -466,6 +466,7 @@ internal class PlayerImpl(override val theoplayerView: THEOplayerView?) : Player
         theoplayerView?.findViewById<View>(com.theoplayer.android.R.id.theo_player_container)
             ?.let { FullscreenHandlerImpl(it) }
     private var _fullscreen by mutableStateOf(false)
+    private var onExitFullscreen: (() -> Unit)? = null
     override var fullscreen: Boolean
         get() = _fullscreen
         set(value) {
@@ -479,6 +480,10 @@ internal class PlayerImpl(override val theoplayerView: THEOplayerView?) : Player
 
     private fun updateFullscreen() {
         _fullscreen = fullscreenHandler?.fullscreen ?: false
+        if (!fullscreen) {
+            onExitFullscreen?.let { it() }
+            onExitFullscreen = null
+        }
     }
 
     val fullscreenListener =
@@ -492,7 +497,12 @@ internal class PlayerImpl(override val theoplayerView: THEOplayerView?) : Player
     }
 
     override fun enterPictureInPicture(pipType: PiPType) {
-        theoplayerView?.piPManager?.enterPiP(pipType)
+        if (fullscreen) {
+            onExitFullscreen = { theoplayerView?.piPManager?.enterPiP(pipType) }
+            fullscreen = false
+        } else {
+            theoplayerView?.piPManager?.enterPiP(pipType)
+        }
     }
 
     override fun exitPictureInPicture() {

--- a/ui/src/main/java/com/theoplayer/android/ui/Player.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/Player.kt
@@ -1,5 +1,6 @@
 package com.theoplayer.android.ui
 
+import android.app.Activity
 import android.view.View
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
@@ -189,6 +190,11 @@ interface Player {
      * Returns whether the player is showing in picture-in-picture mode.
      */
     val pictureInPicture: Boolean
+
+    /**
+     * Returns whether the player supports entering picture-in-picture mode.
+     */
+    val pictureInPictureSupported: Boolean
 
     /**
      * Returns whether the player is currently waiting for more data to resume playback.
@@ -480,6 +486,10 @@ internal class PlayerImpl(override val theoplayerView: THEOplayerView?) : Player
 
     override var pictureInPicture: Boolean by mutableStateOf(false)
         private set
+
+    override val pictureInPictureSupported: Boolean by lazy {
+        (theoplayerView?.context as? Activity)?.supportsPictureInPictureMode() ?: false
+    }
 
     override fun enterPictureInPicture(pipType: PiPType) {
         theoplayerView?.piPManager?.enterPiP(pipType)

--- a/ui/src/main/java/com/theoplayer/android/ui/Util.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/Util.kt
@@ -1,0 +1,18 @@
+package com.theoplayer.android.ui
+
+import android.app.Activity
+import android.content.pm.PackageManager
+import android.os.Build
+
+// From android.content.pm.ActivityInfo
+private const val FLAG_SUPPORTS_PICTURE_IN_PICTURE = 0x400000
+
+/**
+ * Check if the given activity supports [Activity.enterPictureInPictureMode].
+ */
+internal fun Activity.supportsPictureInPictureMode(): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return false
+    if (!packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)) return false
+    val info = packageManager.getActivityInfo(componentName, 0)
+    return (info.flags and FLAG_SUPPORTS_PICTURE_IN_PICTURE) != 0
+}

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -95,4 +95,13 @@
 
     <!-- The title for a fatal error, shown above the full error message. -->
     <string name="theoplayer_ui_error_title">An error occurred</string>
+
+    <!-- The label shown for entering picture-in-picture. -->
+    <string name="theoplayer_ui_pip_enter">Enter picture-in-picture</string>
+
+    <!-- The label shown for exiting picture-in-picture. -->
+    <string name="theoplayer_ui_pip_exit">Exit picture-in-picture</string>
+
+    <!-- The label shown when picture-in-picture is active. -->
+    <string name="theo_pip_placeholder">Video playing in PiP mode.</string>
 </resources>


### PR DESCRIPTION
This adds a `PictureInPictureButton` to enter or exit picture-in-picture mode using THEOplayer's [`PiPManager` API](https://optiview.dolby.com/docs/theoplayer/v9/api-reference/android/com/theoplayer/android/api/pip/PiPManager.html) ([docs](https://optiview.dolby.com/docs/theoplayer/how-to-guides/miscellaneous/picture-in-picture/#android--fire-tv-sdk)). The button is automatically shown when the activity has `android:supportsPictureInPictureMode="true"` [(docs)](https://developer.android.com/develop/ui/views/picture-in-picture#declaring).

Fixes #19.
Supersedes #51.