### PR TITLE
Fix menu background not showing properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 🐛 Fixed the menu background disappearing after opening. ([#100](https://github.com/THEOplayer/android-ui/pull/100))
+
 ## v1.14.0 (2026-04-20)
 
 * 🚀 Added support for THEOplayer 11.0. ([#98](https://github.com/THEOplayer/android-ui/pull/98))

--- a/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
+++ b/ui/src/main/java/com/theoplayer/android/ui/UIController.kt
@@ -224,6 +224,7 @@ fun UIController(
             AnimatedContent(
                 label = "ContentAnimation",
                 modifier = Modifier
+                    .fillMaxSize()
                     .background(background),
                 targetState = uiState,
                 transitionSpec = {


### PR DESCRIPTION
Something broke when updating to Jetpack Compose 1.10.6 in #98 with the `AnimatedVisibility`... I think this fixes it.